### PR TITLE
Add a Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 env:
   - OCAML_VERSION=4.02 INSTALL_XQUARTZ=false
   - OCAML_VERSION=4.03 INSTALL_XQUARTZ=false
+  - OCAML_VERSION=4.04 INSTALL_XQUARTZ=false
 sudo: required
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: c
+os:
+  - linux
+  - osx
+env:
+  - OCAML_VERSION=4.03 INSTALL_XQUARTZ=false
+sudo: required
+install:
+  - wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-ocaml.sh
+  - bash -ex .travis-ocaml.sh
+  - ./configure
+  - make
+  - sudo make install
+script:
+  - cd test
+  - omake

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 env:
+  - OCAML_VERSION=4.02 INSTALL_XQUARTZ=false
   - OCAML_VERSION=4.03 INSTALL_XQUARTZ=false
 sudo: required
 install:


### PR DESCRIPTION
Hello.

I think OMake needs CI(Continuous Integration). So I wrote a setting file for [Travis CI](https://travis-ci.org/)
## What is Travis CI?

Wikipedia says

> Travis CI is a hosted, distributed continuous integration service used to build and test software projects hosted at GitHub.

See also https://travis-ci.org/

This `.travis.yml` will do the following: 
1. install OCaml
2. `./configure`
3. `make`
4. `make install`
5. change the `test` directory
6. `omake`

See also [.travis.yml](https://github.com/y-yu/omake/blob/master/.travis.yml)
## Example Result

https://travis-ci.org/y-yu/omake/builds/165228847

Thanks.
