### PR TITLE
Figure out the C compiler used by ocamlc

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -104,9 +104,18 @@ open configure/Configure
 # \varlabel{EXTENDED_DIGESTS}{EXTENDED\_DIGESTS} Whether to include more information into
 #   rule digests and make it more sensitive to structural changes at the cost
 #   of build speed (\verb+true+ or \verb+false+).
+# \varlabel{OCAML_CC}{OCAML\_CC} The C compiler used internally by OCaml
+# \varlabel{OCAML_CFLAGS}{OCAML\_CFLAGS} The C compiler flags used by OCaml
 # \end{doc}
 #
 public.USE_OCAMLFIND = false
+
+private.get_bytecomp_c_comp() =
+    private.config = $(concat $(unhexify 0a), $(shella ocamlc -config)))
+    private.configch = $(open-in-string $(config))
+    scan($(configch))
+    case $"bytecomp_c_compiler:"
+        return $(nth-tl 1, $*)
 
 .STATIC: :value: $(PATH)
     OCAMLFIND_EXISTS = $(CheckProg ocamlfind)
@@ -140,6 +149,12 @@ public.USE_OCAMLFIND = false
     CMXS_ENABLED = false
     #
     EXTENDED_DIGESTS = false
+    #
+    # Figure out the params for the C compiler
+    #
+    private.bytecomp_c_comp = $(get_bytecomp_c_comp)
+    OCAML_CC = $(nth-hd 1, $(bytecomp_c_comp))
+    OCAML_CFLAGS = $(nth-tl 1, $(bytecomp_c_comp))
 
 public.OCAMLFIND = $`(if $(USE_OCAMLFIND), ocamlfind)
 public.OCAMLFINDFLAGS =

--- a/mk/osconfig_mingw.mk
+++ b/mk/osconfig_mingw.mk
@@ -22,8 +22,8 @@ OCAMLDEP = ocamldep$(OCAMLSUFFIX)
 #
 # C configuration
 #
-CC := $(shell sh -c "$(OCAMLC) -config | grep bytecomp_c_compiler | awk '{print $$2}'")
-CFLAGS = -I"$(STDLIB)" -I"$(STDLIB)/caml" 
+CC = $(OCAML_CC)
+CFLAGS = $(OCAML_CFLAGS) -I"$(STDLIB)" -I"$(STDLIB)/caml" 
 AR = ar cq
 AROUT =
 EXT_OBJ = .o

--- a/mk/osconfig_unix.mk
+++ b/mk/osconfig_unix.mk
@@ -22,8 +22,8 @@ OCAMLDEP = ocamldep$(OCAMLSUFFIX)
 #
 # C configuration
 #
-CC = cc
-CFLAGS = -I"$(STDLIB)" -I"$(STDLIB)/caml" 
+CC = $(OCAML_CC)
+CFLAGS = $(OCAML_CFLAGS) -I"$(STDLIB)" -I"$(STDLIB)/caml" 
 AR = ar cq
 AROUT =
 EXT_OBJ = .o

--- a/src/clib/OMakefile
+++ b/src/clib/OMakefile
@@ -30,6 +30,9 @@ EXTERNAL = ../libmojave-external
 
 # CGeneratedFiles($(CUTIL_FILES))
 
+CC = $(OCAML_CC)
+CFLAGS = $(OCAML_CFLAGS)
+
 open configure/snprintf
 open configure/posix_spawn
 open configure/fs_case_sensitive

--- a/src/clib/lm_ctype.c
+++ b/src/clib/lm_ctype.c
@@ -30,6 +30,7 @@
  * @end[license]
  */
 #include <memory.h>
+#include <string.h>
 #include <ctype.h>
 
 #include <caml/mlvalues.h>

--- a/src/clib/lm_heap.c
+++ b/src/clib/lm_heap.c
@@ -82,16 +82,16 @@ static void search_pointer(char **pointers, char *name, unsigned bound, char *p,
     
 static void lm_heap_check_aux1(char *name)
 {
-    char *start, *ptr, *end;
+    /* char *start, *ptr, *end; */
     char *v;
     value p, *next;
     mlsize_t size;
     unsigned i, index, found;
 	 char *pointers[1 << 16];
 
-    start = caml_young_start;
-    ptr = caml_young_ptr;
-    end = caml_young_end;
+    /* start = caml_young_start; */
+    /* ptr = caml_young_ptr; */
+    /* end = caml_young_end; */
 
     fprintf(stderr, "AAA: %s: [0x%08lx, 0x%08lx, 0x%08lx, 0x%08lx] (%ld/%ld/%ld bytes)\n",
             name,
@@ -167,15 +167,15 @@ static void lm_heap_check_aux1(char *name)
 
 static void lm_heap_check_aux2(char *name)
 {
-    char *start, *ptr, *end;
+    /* char *start, *ptr, *end; */
     char *v;
     header_t hd;
     mlsize_t size;
     unsigned i;
 
-    start = caml_young_start;
-    ptr = caml_young_ptr;
-    end = caml_young_end;
+    /* start = caml_young_start; */
+    /* ptr = caml_young_ptr; */
+    /* end = caml_young_end; */
 
     fprintf(stderr, "AAA: %s: [0x%08lx, 0x%08lx, 0x%08lx, 0x%08lx] (%ld/%ld/%ld bytes)\n",
             name,

--- a/src/clib/lm_unix_cutil.c
+++ b/src/clib/lm_unix_cutil.c
@@ -28,7 +28,6 @@ CAMLprim value
 caml_eff_string_compare(value s1, value s2)
 {
   mlsize_t len1, len2;
-  int res;
 
   if (s1 == s2) return Val_int(0);
   len1 = caml_string_length(s1);
@@ -336,6 +335,7 @@ static int flock_of_flock[] = {
 };
 #endif
 
+#if !defined(FLOCK_ENABLED) && defined(FCNTL_ENABLED)
 #if defined(F_RDLCK) && defined(F_WRLCK) && defined(F_UNLCK) && defined(F_SETLK) && defined(F_SETLKW) && defined(SEEK_SET)
 #define FCNTL_ENABLED
 static int fcntl_type_of_flock[] = {
@@ -354,7 +354,9 @@ static int fcntl_of_flock[] = {
     F_SETLK
 };
 #endif
+#endif
 
+#if !defined(FLOCK_ENABLED) && !defined(FCNTL_ENABLED) && defined(LOCKF_ENABLED)
 #if defined(F_ULOCK) && defined(F_LOCK) && defined(F_TLOCK)
 #define LOCKF_ENABLED
 static int lockf_of_flock[] = {
@@ -364,6 +366,7 @@ static int lockf_of_flock[] = {
     F_TLOCK,
     F_TLOCK
 };
+#endif
 #endif
 
 value lm_flock(value v_fd, value v_op)

--- a/src/clib/readline.c
+++ b/src/clib/readline.c
@@ -94,8 +94,10 @@
 /*
  * Name of the command completion callback.
  */
+#ifdef READLINE_ENABLED
 static char omake_filename_completion[] = "omake_filename_completion";
 static char omake_command_completion[]  = "omake_command_completion";
+#endif
 
 /************************************************************************
  * Completions.
@@ -115,6 +117,7 @@ typedef struct _completion_info {
 /*
  * Command completions use a callback.
  */
+#ifdef READLINE_ENABLED
 static char **readline_completion(char *omake_completion, const char *text)
 {
     CAMLparam0();
@@ -153,6 +156,7 @@ static char **readline_completion(char *omake_completion, const char *text)
     completions[i] = 0;
     CAMLreturnT(char **, completions);
 }
+#endif
 
 /************************************************************************
  * Readline simulation for Win32.
@@ -1349,8 +1353,10 @@ static void do_readline(ReadLine *readp, const char *promptp)
 /*
  * History file and length.
  */
+#ifdef READLINE_ENABLED
 static char readline_file[2048];
 static int readline_length;
+#endif
 
 static void do_readline_load_file(const char *filep)
 {


### PR DESCRIPTION
At bootstrap time, build.ml calls `ocamlc -config` and sets the two variables `OCAML_CC` and `OCAML_CFLAGS`. The variables are appended to osconfig.mk.

In a normal build, the two variables are figured out by `OCaml.om` and are generally available. With

```
CC = $(OCAML_CC)
CFLAGS = $(OCAML_CFLAGS)
```

you can take over these values for your own build.
