### PR TITLE
Fix opam removal

### DIFF
--- a/opam
+++ b/opam
@@ -15,7 +15,16 @@ bug-reports: "https://github.com/ocaml-omake/issues"
 build: [
   ["./configure" "-prefix" "%{prefix}%"]
   [make]
+]
+
+install: [
   [make "install"]
+]
+
+remove: [
+  [ "rm" "-f" "%{prefix}%/bin/omake" ]
+  [ "rm" "-f" "%{prefix}%/bin/osh" ]
+  [ "rm" "-rf" "%{prefix}%/lib/omake" ]
 ]
 
 depends: ["ocamlfind"]


### PR DESCRIPTION
Tell opam which paths it needs to delete to uninstall omake correctly. Also,
split build and install appropriately.