### PR TITLE
Lm_printf.flush must be used to flush output of Lm_printf.printf

### DIFF
--- a/src/builtin/omake_builtin_file.ml
+++ b/src/builtin/omake_builtin_file.ml
@@ -1931,7 +1931,7 @@ let rm_aux unlink info filename =
          if info.rm_interactive then
             begin
                Lm_printf.printf "Remove %s? " filename;
-               flush stdout;
+               Lm_printf.flush Lm_printf.std_formatter;
                match String.lowercase (Lm_string_util.trim (input_line stdin)) with
                   "y" | "yes" ->
                      true

--- a/src/ir/omake_install.ml
+++ b/src/ir/omake_install.ml
@@ -11,7 +11,7 @@
 let copy_file force src dst =
    let prompt () =
       Lm_printf.printf "%s already exists, overwrite (yes/no)? " dst;
-      flush stdout;
+      Lm_printf.flush Lm_printf.std_formatter;
       String.lowercase (input_line stdin) = "yes"
    in
       if force || not (Sys.file_exists dst) || prompt () then


### PR DESCRIPTION
This should fix  #83 . 

`open Lm_printf` is removed and `printf` is qualified with `Lm_printf` in omake.0.10, but the following `flush` is not qualified correctly.  I found 2 such `flush`es so far.