### PR TITLE
Fix installation issues

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -114,7 +114,7 @@ private.get_bytecomp_c_comp() =
     private.config = $(concat $(unhexify 0a), $(shella ocamlc -config)))
     private.configch = $(open-in-string $(config))
     scan($(configch))
-    case $"bytecomp_c_compiler:"
+    case $"c_compiler:"
         return $(nth-tl 1, $*)
 
 .STATIC: :value: $(PATH)

--- a/src/libmojave/lm_printf.mli
+++ b/src/libmojave/lm_printf.mli
@@ -158,11 +158,6 @@ val pp_force_newline             : formatter -> unit -> unit
 val pp_print_flush               : formatter -> unit -> unit
 val pp_print_newline             : formatter -> unit -> unit
 val pp_print_if_newline          : formatter -> unit -> unit
-val pp_open_tbox                 : formatter -> unit -> unit
-val pp_close_tbox                : formatter -> unit -> unit
-val pp_print_tbreak              : formatter -> int -> int -> unit
-val pp_set_tab                   : formatter -> unit -> unit
-val pp_print_tab                 : formatter -> unit -> unit
 val pp_set_margin                : formatter -> int -> unit
 val pp_get_margin                : formatter -> unit -> int
 val pp_set_max_indent            : formatter -> int -> unit


### PR DESCRIPTION
This PR fixes installation issue #93, enables omake to compile at Ocaml version `4.06.0+dev1-2017-06-23` (as obtained via opam)