### PR TITLE
Fix error in bootstrap build with Xcode tools on macOS.

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -181,7 +181,7 @@ private.get_bytecomp_c_comp() =
     # Figure out the params for the C compiler
     #
     private.c_comp = $(get_c_comp)
-    if $(equal X$(c_comp)X, XX)
+    if $(equal $(string X$(c_comp)X), XX)
         private.bytecomp_c_comp = $(get_bytecomp_c_comp)
         OCAML_CC = $(nth-hd 1, $(bytecomp_c_comp))
         OCAML_CFLAGS = $(nth-tl 1, $(bytecomp_c_comp))


### PR DESCRIPTION
OMake 0.10.3 fails to install in the OPAM switch for 4.06.0 on macOS with Xcode tools.

```
# *** omake: reading OMakefiles
# --- Checking for ocamlfind... (found /Users/jhw/.opam/4.06.0/bin/ocamlfind)
# --- Checking for ocamlc.opt... (found /Users/jhw/.opam/4.06.0/bin/ocamlc.opt)
# --- Checking for ocamlopt.opt... (found /Users/jhw/.opam/4.06.0/bin/ocamlopt.opt)
# --- Checking for ocamldep.opt... (found /Users/jhw/.opam/4.06.0/bin/ocamldep.opt)
# --- Checking for ocamllex.opt... (found /Users/jhw/.opam/4.06.0/bin/ocamllex.opt)
# --- Checking whether ocamlc understands the "z" warnings... (yes)
# --- Checking whether ocamlopt can create cmxs plugins... (yes)
### stderr ###
# *** omake error:
# [...]
#    Array value where string expected:
#       Use the $(string ...) function if you really want to do this
#       The array has length 3:
#          [0] = <data "cc"> : String
#          [1] = <data "-O2"> : String
#          [2] = <data "-pipe"> : String
# 
# Command exited with error: boot/omake '--dotomake' '.omake' '--force-dotomake' 'main' 'OCAML=ocaml'
# make: *** [bootstrap] Error 1

```
This patch corrects the error.