### PR TITLE
C compiler configuration

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -181,7 +181,7 @@ private.get_bytecomp_c_comp() =
     # Figure out the params for the C compiler
     #
     private.c_comp = $(get_c_comp)
-    if $(equal X$(c_comp)X, XX)
+    if $(equal X$(string $(c_comp))X, XX)
         private.bytecomp_c_comp = $(get_bytecomp_c_comp)
         OCAML_CC = $(nth-hd 1, $(bytecomp_c_comp))
         OCAML_CFLAGS = $(nth-tl 1, $(bytecomp_c_comp))


### PR DESCRIPTION
fix: configuration of C compiler for the case that "ocamlc -config" prints several words for "c_compiler"