### PR TITLE
Add functions `empty-array` and `empty-string`

### DIFF
--- a/doc/src/omake-language-examples.tex
+++ b/doc/src/omake-language-examples.tex
@@ -167,14 +167,14 @@ These quotations have several properties:
     - : "[gnirts )\\elpmaxe(\\ '''' na )SI($ ereH" : String
 \end{verbatim}
 
-You can define an empty string as
+You can define an empty sequence as
 
 \begin{verbatim}
     X =
 \end{verbatim}
 
 but in expression context it is often more convenient to get the empty
-string via the function call \verb+$(string)+.
+string via the function call \verb+$(empty-string)+.
 
 \section{Merging}
 \label{section:merging}

--- a/doc/src/omake-language.tex
+++ b/doc/src/omake-language.tex
@@ -110,11 +110,11 @@ double-quotations is arbitrary.  The outermost quotations are not included in th
         The # character is not special"""
 \end{verbatim}
 
-Note that it is not possible to denote the empty string with this notation.
-As a workaround, call the \verb+string+ function without parameters, as in
+Note that it is \emph{not} possible to denote the empty string with
+this notation; use function~\verb+empty-string+ for that purpose
 
 \begin{verbatim}
-    EMPTY = $(string)
+    EMPTY = $(empty-string)
 \end{verbatim}
 
 \section{Function definitions}

--- a/lib/Pervasives.om
+++ b/lib/Pervasives.om
@@ -72,8 +72,8 @@ shell-success-null(argv) =
    rm(-f $(tmp))
    return $(res)
 
-last(array) =
-   return $(nth $(sub $(length $(array)), 1), $(array))
+last(an_array) =
+   return $(nth $(sub $(length $(an_array)), 1), $(an_array))
 
 Bool(v) =
    value $(not $(not $v))

--- a/lib/build/C.om
+++ b/lib/build/C.om
@@ -96,7 +96,7 @@ open configure/Configure
 # if foo-g++ exists, and fallback otherwise
 
 protected.toolchain-derive(cc, command, fallback) =
-    empty = $(array)
+    empty = $(empty-array)
     match $(cc)
     case $"\(.*\)-g?cc"
         fullcmd = $(concat $(empty), $1 $(command))

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -117,7 +117,7 @@ private.get_c_comp() =
     scan($(configch))
     case $"c_compiler:"
         return $(nth-tl 1, $*)
-    return $(string)
+    return $(empty-string)
 
 private.get_bytecomp_cflags() =
     # since OCaml-4.06
@@ -126,7 +126,7 @@ private.get_bytecomp_cflags() =
     scan($(configch))
     case $"ocamlc_cflags:"
         return $(nth-tl 1, $*)
-    return $(string)
+    return $(empty-string)
 
 private.get_bytecomp_cppflags() =
     # since OCaml-4.06
@@ -135,7 +135,7 @@ private.get_bytecomp_cppflags() =
     scan($(configch))
     case $"ocamlc_cppflags:"
         return $(nth-tl 1, $*)
-    return $(string)
+    return $(empty-string)
 
 private.get_bytecomp_c_comp() =
     private.config = $(concat $(unhexify 0a), $(shella ocamlc -config)))
@@ -143,7 +143,7 @@ private.get_bytecomp_c_comp() =
     scan($(configch))
     case $"bytecomp_c_compiler:"
         return $(nth-tl 1, $*)
-    return $(string)
+    return $(empty-string)
 
 .STATIC: :value: $(PATH)
     OCAMLFIND_EXISTS = $(CheckProg ocamlfind)

--- a/src/builtin/omake_builtin_base.ml
+++ b/src/builtin/omake_builtin_base.ml
@@ -1460,10 +1460,13 @@ let rev_fun venv pos loc args : Omake_value_type.t =
  *       sequence : Sequence
  * \end{verbatim}
  *
- * The \verb+string+ function flattens a sequence into a single string.
+ * The \verb+string+ function flattens a non-empty sequence into a single string.
  * This is similar to the \verb+concat+ function, but the elements are
  * separated by whitespace.  The result is treated as a unit; whitespace
  * is significant.
+ *
+ * Note: function~\verb+string+ cannot construct an empty string;
+ * use \verb+$(empty-string)+ for that purpose.
  * \end{doc}
  *)
 let string venv pos loc args : Omake_value_type.t =
@@ -1475,6 +1478,25 @@ let string venv pos loc args : Omake_value_type.t =
     ValData s
   | _ ->
     raise (Omake_value_type.OmakeException (loc_pos loc pos, ArityMismatch (ArityExact 1, List.length args)))
+
+(*
+ * \begin{doc}
+ * \fun{empty-string}
+ *
+ * \begin{verbatim}
+ *    $(empty-string) : String
+ * \end{verbatim}
+ *
+ * Answer an empty string.
+ * \end{doc}
+ *)
+let empty_string _venv pos loc args : Omake_value_type.t =
+  let pos' = string_pos "empty-string" pos
+  and n = List.length args in
+    if n = 0 then
+      ValData ""
+    else
+      raise (Omake_value_type.OmakeException (loc_pos loc pos', ArityMismatch (ArityExact 0, n)))
 
 (*
  * \begin{doc}
@@ -2847,6 +2869,7 @@ let () =
 
      (* String operations *)
      true,  "string",                string,              ArityExact 1;
+     true,  "empty-string",          empty_string,        ArityExact 0;
      true,  "string-escaped",        string_escaped,      ArityExact 1;
      true,  "string-length",         string_length,       ArityExact 1;
      true,  "ocaml-escaped",         ocaml_escaped,       ArityExact 1;

--- a/src/builtin/omake_builtin_base.ml
+++ b/src/builtin/omake_builtin_base.ml
@@ -1093,7 +1093,7 @@ let setvar venv pos loc args kargs =
  *        elements : Sequence
  * \end{verbatim}
  *
- * The \verb+array+ function creates an array from a sequence.
+ * The \verb+array+ function creates an array from a non-empty sequence.
  * If the \verb+<arg>+ is a string, the elements of the array
  * are the whitespace-separated elements of the string, respecting
  * quotes.
@@ -1110,6 +1110,9 @@ let setvar venv pos loc args kargs =
  * In this case, the elements of the array are exactly
  * \verb+<val1>+, ..., \verb+<valn>+, and whitespace is
  * preserved literally.
+ *
+ * Note: function~\verb+array+ cannot construct an empty array;
+ * use \verb+$(empty-array)+ for that purpose.
  * \end{doc}
 *)
 let array_fun venv pos _ args : Omake_value_type.t =
@@ -1120,6 +1123,27 @@ let array_fun venv pos _ args : Omake_value_type.t =
                List.rev_append args' args) [] args
    in
       ValArray (List.rev args)
+
+(*
+ * Create an empty array.
+ *
+ * \begin{doc}
+ * \fun{empty-array}
+ *
+ * \begin{verbatim}
+ *    $(empty-array) : Array
+ * \end{verbatim}
+ *
+ * Answer an empty array.
+ * \end{doc}
+ *)
+let empty_array_fun _venv pos loc args : Omake_value_type.t =
+  let pos' = string_pos "empty-array" pos
+  and n = List.length args in
+    if n = 0 then
+      ValArray []
+    else
+      raise (Omake_value_type.OmakeException (loc_pos loc pos', ArityMismatch (ArityExact 0, n)))
 
 (*
  * Concatenate the strings with a separator.
@@ -2913,6 +2937,7 @@ let () =
 
      (* List operations *)
      true,  "array",                 array_fun,           ArityAny;
+     true,  "empty-array",           empty_array_fun,     ArityExact 0;
      true,  "split",                 split_fun,           ArityRange (1, 2);
      true,  "concat",                concat_fun,          ArityExact 2;
      true,  "filter",                filter,              ArityExact 2;


### PR DESCRIPTION
OMake has not yet offered *clearly* named functions to create empty arrays
or empty strings.  Even the documentation is wrong on the result of `$(string)`,
so is a part of the OMake library.

This branch
 * introduces function `empty-array` that is new and supersedes `EMPTY_ARRAY`,
 * adds function `empty-string`, which makes the change backward compatible,
 * brings the documentation and parts of the library to a consistent state with the new functions.
