### PR TITLE
Fix warnings about discarded `const' from pointer types.

### DIFF
--- a/src/clib/lm_ctype.c
+++ b/src/clib/lm_ctype.c
@@ -61,7 +61,7 @@ static value get_chars(int (*f)(int))
             *p++ = (char) i;
     }
     s = alloc_string(p - buf);
-    memcpy(String_val(s), buf, p - buf);
+    memcpy(Bp_val(s), buf, p - buf);
     return s;
 }
 

--- a/src/clib/lm_printf.c
+++ b/src/clib/lm_printf.c
@@ -29,7 +29,7 @@
 value ml_print_char(value v_fmt, value v_char)
 {
     char buffer[BUFSIZE];
-    char *fmt = String_val(v_fmt);
+    const char *fmt = String_val(v_fmt);
     char c = (char) Int_val(v_char);
 #ifdef HAVE_SNPRINTF
     if(snprintf(buffer, sizeof(buffer), fmt, c) < 0)
@@ -47,7 +47,7 @@ value ml_print_char(value v_fmt, value v_char)
 value ml_print_int(value v_fmt, value v_int)
 {
     char buffer[BUFSIZE];
-    char *fmt = String_val(v_fmt);
+    const char *fmt = String_val(v_fmt);
     int i = Int_val(v_int);
 #ifdef HAVE_SNPRINTF
     if(snprintf(buffer, sizeof(buffer), fmt, i) < 0)
@@ -66,7 +66,7 @@ value ml_print_int(value v_fmt, value v_int)
 value ml_print_float(value v_fmt, value v_float)
 {
     char buffer[BUFSIZE];
-    char *fmt = String_val(v_fmt);
+    const char *fmt = String_val(v_fmt);
     double x = Double_val(v_float);
 #ifdef HAVE_SNPRINTF
     if(snprintf(buffer, sizeof(buffer), fmt, x) < 0)
@@ -85,7 +85,7 @@ value ml_print_string(value v_fmt, value v_string)
 {
     char buffer[BUFSIZE], *bufp;
     int len, size, code;
-    char *fmt, *s;
+    const char *fmt, *s;
     value v_result;
 
     /* Degenerate case if the format is %s */
@@ -130,7 +130,7 @@ value ml_print_string2(value v_width, value v_fmt, value v_string)
 {
     char buffer[BUFSIZE], *bufp;
     int width, len, size, code;
-    char *fmt, *s;
+    const char *fmt, *s;
     value v_result;
 
     /* Degenerate case if the format is %s */

--- a/src/clib/omake_shell_spawn.c
+++ b/src/clib/omake_shell_spawn.c
@@ -168,7 +168,7 @@ CAMLprim value omake_shell_spawn_compat_nat(value v_chdir,
     sub_argv = malloc((Wosize_val(v_args) + 1) * sizeof(char *));
     if (sub_argv == NULL) MAIN_ERROR(ENOMEM, "Omake_shell_spawn/malloc [020]");
     for (k = 0; k < Wosize_val(v_args); k++) {
-	sub_argv[k] = String_val(Field(v_args, k));
+	sub_argv[k] = Bp_val(Field(v_args, k));
     }
     sub_argv[ Wosize_val(v_args)] = NULL;
     cleanup_sub_argv = 1;
@@ -176,7 +176,7 @@ CAMLprim value omake_shell_spawn_compat_nat(value v_chdir,
     sub_env = malloc((Wosize_val(v_env) + 1) * sizeof(char *));
     if (sub_env == NULL) MAIN_ERROR(ENOMEM, "Omake_shell_spawn/malloc [021]");
     for (k = 0; k < Wosize_val(v_env); k++) {
-	sub_env[k] = String_val(Field(v_env, k));
+	sub_env[k] = Bp_val(Field(v_env, k));
     }
     sub_env[ Wosize_val(v_env)] = NULL;
     cleanup_sub_env = 1;
@@ -585,7 +585,7 @@ CAMLprim value omake_shell_spawn_posix_nat(value v_pg,
     sub_argv = malloc((Wosize_val(v_args) + 1) * sizeof(char *));
     if (sub_argv == NULL) MAIN_ERROR(ENOMEM, "omake_shell_spawn_posix/malloc [1]");
     for (k = 0; k < Wosize_val(v_args); k++) {
-	sub_argv[k] = String_val(Field(v_args, k));
+	sub_argv[k] = Bp_val(Field(v_args, k));
     }
     sub_argv[ Wosize_val(v_args)] = NULL;
     cleanup_sub_argv = 1;
@@ -593,7 +593,7 @@ CAMLprim value omake_shell_spawn_posix_nat(value v_pg,
     sub_env = malloc((Wosize_val(v_env) + 1) * sizeof(char *));
     if (sub_env == NULL) MAIN_ERROR(ENOMEM, "omake_shell_spawn_posix/malloc [2]");
     for (k = 0; k < Wosize_val(v_env); k++) {
-	sub_env[k] = String_val(Field(v_env, k));
+	sub_env[k] = Bp_val(Field(v_env, k));
     }
     sub_env[ Wosize_val(v_env)] = NULL;
     cleanup_sub_env = 1;

--- a/src/clib/readline.c
+++ b/src/clib/readline.c
@@ -1552,7 +1552,7 @@ value omake_readline(value v_prompt)
 
     /* Copy it to the buffer */
     v_str = caml_alloc_string(readp->length);
-    memcpy(String_val(v_str), readp->buffer, readp->length);
+    memcpy(Bp_val(v_str), readp->buffer, readp->length);
 
     /* Reset the current buffer */
     readp->index = 0;
@@ -1566,7 +1566,8 @@ value omake_readline(value v_prompt)
 value omake_readstring(value v_prompt, value v_buf, value v_off, value v_len)
 {
     int off, len, amount;
-    char *buf, *prompt;
+    char *buf;
+    const char *prompt;
 
     /* If the buffer is empty, read the next line */
     prompt = String_val(v_prompt);
@@ -1577,7 +1578,7 @@ value omake_readstring(value v_prompt, value v_buf, value v_off, value v_len)
     }
 
     /* Get as much as possible */
-    buf = String_val(v_buf);
+    buf = Bp_val(v_buf);
     off = Int_val(v_off);
     len = Int_val(v_len);
     amount = readp->length - readp->index;

--- a/src/clib/readline.c
+++ b/src/clib/readline.c
@@ -123,7 +123,6 @@ static char **readline_completion(char *omake_completion, const char *text)
     CAMLparam0();
     CAMLlocal2(request, response);
     char *namep, **completions;
-    value *callbackp;
     int i, length;
 
 #ifdef WIN32
@@ -131,15 +130,17 @@ static char **readline_completion(char *omake_completion, const char *text)
     (void) caml__dummy_request;
 #endif
 
-    /* Find the callback, abort if it doesn't exist */
-    callbackp = caml_named_value(omake_completion);
-    if(callbackp == 0 || *callbackp == 0)
-        CAMLreturnT(char **, 0);
+    {
+        /* Find the callback, abort if it doesn't exist */
+        const value *callbackp = caml_named_value(omake_completion);
+        if(callbackp == 0 || *callbackp == 0)
+            CAMLreturnT(char **, 0);
 
-    /* The callback returns an array of strings */
-    request = caml_copy_string(text);
-    response = caml_callback(*callbackp, request);
-    
+        /* The callback returns an array of strings */
+        request = caml_copy_string(text);
+        response = caml_callback(*callbackp, request);
+    }
+
     /* Copy the array of strings */
     length = Wosize_val(response);
     if(length == 0)


### PR DESCRIPTION
All these warning messages (`-Wdiscarded-qualifiers`) arise because of
the migration to OCaml safe-strings which change the expansion of the
`String_val` macro.

The patch uses appropriate macros and types to reflect the "const-ness"
of the strings on the heap.  It does *not* change the object code, i.e. is
provably functionally neutral.
