### PR TITLE
Add function `tmpdir' similar to `tmpfile'.

### DIFF
--- a/src/builtin/omake_builtin_file.ml
+++ b/src/builtin/omake_builtin_file.ml
@@ -96,6 +96,39 @@ let dir venv pos loc args =
 
 (*
  * \begin{doc}
+ * \fun{tmpdir}
+ *
+ * \begin{verbatim}
+ *     $(tmpdir prefix) : Dir
+ *     $(tmpdir prefix, suffix) : Dir
+ *         prefix : String
+ *         suffix : String
+ * \end{verbatim}
+ *
+ * The \verb+tmpdir+ function returns the name of a fresh temporary directory in
+ * the temporary directory.
+ *
+ * Override the current temporary directory from \OMake{} with \verb+setenv+.
+ *
+ * See also function~\verb+tmpfile+ for creating a single temporary file.
+ * \end{doc}
+ *)
+let tmpdir venv pos loc args : Omake_value_type.t =
+  let pos' = string_pos "tmpdir" pos in
+    let prefix, suffix =
+      match args with
+      | [prefix] ->
+         Omake_value.string_of_value venv pos' prefix, ".omake"
+      | [prefix; suffix] ->
+         Omake_value.string_of_value venv pos' prefix, Omake_value.string_of_value venv pos' suffix
+      | _ ->
+         raise (Omake_value_type.OmakeException (loc_pos loc pos',
+                                                 ArityMismatch (ArityRange (1, 2), List.length args)))
+    in
+      Omake_value_type.ValDir (Omake_env.venv_intern_dir venv (Lm_unix_util.temporary_directory prefix suffix))
+
+(*
+ * \begin{doc}
  * \fun{tmpfile}
  *
  * \begin{verbatim}
@@ -107,6 +140,22 @@ let dir venv pos loc args =
  *
  * The \verb+tmpfile+ function returns the name of a fresh temporary file in
  * the temporary directory.
+ *
+ * Override the current temporary directory from \OMake{} with \verb+setenv+.
+ *
+ * One typical usage of \verb+tmpfile+ is within a \verb+section+:
+ * \begin{verbatim}
+ *     section
+ *         setenv(TMPDIR, /dev/shm) # migrate to fast device
+ *         test_file = $(tmpfile compilation-test, .c)
+ *         try
+ *             # Do something with test_file, which might fail.
+ *             # ...
+ *         finally
+ *             rm -f $(test_file)
+ * \end{verbatim}
+ *
+ * See also function~\verb+tmpdir+ for creating a temporary directory.
  * \end{doc}
  *)
 let tmpfile venv pos loc args : Omake_value_type.t =
@@ -2868,6 +2917,7 @@ let () =
      true, "fullname",                fullname,                 ArityExact 1;
      true, "absname",                 absname,                  ArityExact 1;
      true, "suffix",                  suffix,                   ArityExact 1;
+     true, "tmpdir",                  tmpdir,                   ArityRange (1, 2);
      true, "tmpfile",                 tmpfile,                  ArityRange (1, 2);
      true, "file",                    file,                     ArityExact 1;
      true, "dir",                     dir,                      ArityExact 1;

--- a/src/builtin/omake_builtin_file.ml
+++ b/src/builtin/omake_builtin_file.ml
@@ -100,6 +100,7 @@ let get_temp_dir_name venv =
       let root_directory = Omake_env.venv_getenv venv envvar in
         if root_directory = "" then "." else root_directory
     with Not_found -> "."
+and default_temp_suffix = ".omake-temp"
 
 (*
  * \begin{doc}
@@ -108,33 +109,46 @@ let get_temp_dir_name venv =
  * \begin{verbatim}
  *     $(tmpdir prefix) : Dir
  *     $(tmpdir prefix, suffix) : Dir
+ *     $(tmpdir prefix, suffix, root_directory) : Dir
  *         prefix : String
  *         suffix : String
+ *         root_directory : Dir
  * \end{verbatim}
  *
- * The \verb+tmpdir+ function returns the name of a fresh temporary directory in
- * the temporary directory.
+ * The \verb+tmpdir+~function returns the name of a fresh temporary
+ * directory in the temporary directory pointed to by the environment
+ * variable~TEMP (Win32) or TMPDIR (all other operating systems)
+ * unless explicitly given in \verb+root_directory+.  \verb+suffix+
+ * defaults to ".omake-temp".
  *
- * Override the current temporary directory from \OMake{} with \verb+setenv+.
- *
- * See also function~\verb+tmpfile+ for creating a single temporary file.
+ * See also function~\verb+tmpfile+ for creating a single temporary
+ * file.
  * \end{doc}
  *)
 let tmpdir venv pos loc args : Omake_value_type.t =
   let pos' = string_pos "tmpdir" pos in
-    let prefix, suffix =
+    let prefix, suffix, root_directory =
       match args with
       | [prefix] ->
-         Omake_value.string_of_value venv pos' prefix, ".omake"
+         Omake_value.string_of_value venv pos' prefix,
+         default_temp_suffix,
+         get_temp_dir_name venv
       | [prefix; suffix] ->
-         Omake_value.string_of_value venv pos' prefix, Omake_value.string_of_value venv pos' suffix
+         Omake_value.string_of_value venv pos' prefix,
+         Omake_value.string_of_value venv pos' suffix,
+         get_temp_dir_name venv
+      | [prefix; suffix; root_directory'] ->
+         Omake_value.string_of_value venv pos' prefix,
+         Omake_value.string_of_value venv pos' suffix,
+         Omake_value.filename_of_value venv pos' root_directory'
       | _ ->
          raise (Omake_value_type.OmakeException (loc_pos loc pos',
-                                                 ArityMismatch (ArityRange (1, 2), List.length args)))
+                                                 ArityMismatch (ArityRange (1, 3), List.length args)))
     in
-      Omake_value_type.ValDir (Omake_env.venv_intern_dir
-                                 venv
-                                 (Lm_unix_util.temporary_directory ~root_directory:(get_temp_dir_name venv) prefix suffix))
+      Omake_value_type.ValDir
+        (Omake_env.venv_intern_dir
+           venv
+           (Lm_unix_util.temporary_directory ~root_directory prefix suffix))
 
 (*
  * \begin{doc}
@@ -143,19 +157,22 @@ let tmpdir venv pos loc args : Omake_value_type.t =
  * \begin{verbatim}
  *     $(tmpfile prefix) : File
  *     $(tmpfile prefix, suffix) : File
+ *     $(tmpfile prefix, suffix, temp_directory) : File
  *         prefix : String
  *         suffix : String
+ *         temp_directory : Dir
  * \end{verbatim}
  *
- * The \verb+tmpfile+ function returns the name of a fresh temporary file in
- * the temporary directory.
- *
- * Override the current temporary directory from \OMake{} with \verb+setenv+.
+ * The \verb+tmpfile+~function returns the name of a fresh temporary
+ * file in the temporary directory pointed to by the environment
+ * variable~TEMP (Win32) or TMPDIR (all other operating systems)
+ * unless explicitly given in \verb+root_directory+.  \verb+suffix+
+ * defaults to ".omake-temp".
  *
  * One typical usage of \verb+tmpfile+ is within a \verb+section+:
  * \begin{verbatim}
  *     section
- *         setenv(TMPDIR, /dev/shm) # migrate to fast device
+ *         setenv(TMPDIR, /dev/shm)    # migrate to fast device
  *         test_file = $(tmpfile compilation-test, .c)
  *         try
  *             # Do something with test_file, which might fail.
@@ -168,20 +185,29 @@ let tmpdir venv pos loc args : Omake_value_type.t =
  * \end{doc}
  *)
 let tmpfile venv pos loc args : Omake_value_type.t =
-  let pos = string_pos "tmpfile" pos in
-  let prefix, suffix =
+  let pos' = string_pos "tmpfile" pos in
+  let prefix, suffix, temp_dir =
     match args with
     | [prefix] ->
-      Omake_value.string_of_value venv pos prefix, ".omake"
+       Omake_value.string_of_value venv pos' prefix,
+       default_temp_suffix,
+       get_temp_dir_name venv
     | [prefix; suffix] ->
-      Omake_value.string_of_value venv pos prefix, Omake_value.string_of_value venv pos suffix
+       Omake_value.string_of_value venv pos' prefix,
+       Omake_value.string_of_value venv pos' suffix,
+       get_temp_dir_name venv
+    | [prefix; suffix; temp_dir'] ->
+       Omake_value.string_of_value venv pos' prefix,
+       Omake_value.string_of_value venv pos' suffix,
+       Omake_value.filename_of_value venv pos' temp_dir'
     | _ ->
-      raise (Omake_value_type.OmakeException (loc_pos loc pos, ArityMismatch (ArityRange (1, 2), List.length args)))
+       raise (Omake_value_type.OmakeException (loc_pos loc pos',
+                                               ArityMismatch (ArityRange (1, 3), List.length args)))
   in
-    ValNode (Omake_env.venv_intern
-               venv
-               PhonyProhibited
-               (Filename.temp_file ~temp_dir:(get_temp_dir_name venv) prefix suffix))
+    Omake_value_type.ValNode (Omake_env.venv_intern
+                                venv
+                                PhonyProhibited
+                                (Filename.temp_file ~temp_dir prefix suffix))
 
 (*
  * Display something from a different directory.
@@ -2929,8 +2955,8 @@ let () =
      true, "fullname",                fullname,                 ArityExact 1;
      true, "absname",                 absname,                  ArityExact 1;
      true, "suffix",                  suffix,                   ArityExact 1;
-     true, "tmpdir",                  tmpdir,                   ArityRange (1, 2);
-     true, "tmpfile",                 tmpfile,                  ArityRange (1, 2);
+     true, "tmpdir",                  tmpdir,                   ArityRange (1, 3);
+     true, "tmpfile",                 tmpfile,                  ArityRange (1, 3);
      true, "file",                    file,                     ArityExact 1;
      true, "dir",                     dir,                      ArityExact 1;
      true, "which",                   which,                    ArityExact 1;

--- a/src/builtin/omake_builtin_file.ml
+++ b/src/builtin/omake_builtin_file.ml
@@ -143,9 +143,12 @@ let tmpdir venv pos loc args : Omake_value_type.t =
        raise (Omake_value_type.OmakeException (loc_pos loc pos',
                                                ArityMismatch (ArityRange (1, 3), List.length args)))
   in
-    let directory_name = if root_directory = "" || root_directory = "."
-                         then Lm_unix_util.temporary_directory prefix suffix
-                         else Lm_unix_util.temporary_directory ~root_directory prefix suffix in
+    let directory_name =
+      if root_directory = "" || root_directory = "." then
+        Lm_unix_util.temporary_directory prefix suffix
+      else
+        Lm_unix_util.temporary_directory ~root_directory prefix suffix
+    in
       Omake_value_type.ValDir (Omake_env.venv_intern_dir venv directory_name)
 
 (*
@@ -202,9 +205,12 @@ let tmpfile venv pos loc args : Omake_value_type.t =
        raise (Omake_value_type.OmakeException (loc_pos loc pos',
                                                ArityMismatch (ArityRange (1, 3), List.length args)))
   in
-    let filename = if temp_dir = "" || temp_dir = "."
-                   then Filename.temp_file prefix suffix
-                   else Filename.temp_file ~temp_dir prefix suffix in
+    let filename =
+      if temp_dir = "" || temp_dir = "." then
+        Filename.temp_file prefix suffix
+      else
+        Filename.temp_file ~temp_dir prefix suffix
+    in
       Omake_value_type.ValNode (Omake_env.venv_intern venv PhonyProhibited filename)
 
 (*

--- a/src/builtin/omake_builtin_file.ml
+++ b/src/builtin/omake_builtin_file.ml
@@ -98,10 +98,6 @@ let get_temp_dir_name venv =
   let envvar = Lm_symbol.add (match Sys.os_type with "Win32" -> "TEMP" | _ -> "TMPDIR") in
     try Omake_env.venv_getenv venv envvar
     with Not_found -> ""
-and canonicalize_path a_path =
-  Lm_filename_util.split_path a_path |>
-    Lm_filename_util.simplify_path |>
-    Lm_filename_util.concat_path
 and default_temp_suffix = ".omake-temp"
 
 (*
@@ -129,7 +125,7 @@ and default_temp_suffix = ".omake-temp"
  *)
 let tmpdir venv pos loc args : Omake_value_type.t =
   let pos' = string_pos "tmpdir" pos in
-  let prefix, suffix, directory =
+  let prefix, suffix, root_directory =
     match args with
     | [prefix] ->
        Omake_value.string_of_value venv pos' prefix,
@@ -147,13 +143,9 @@ let tmpdir venv pos loc args : Omake_value_type.t =
        raise (Omake_value_type.OmakeException (loc_pos loc pos',
                                                ArityMismatch (ArityRange (1, 3), List.length args)))
   in
-    let root_directory = canonicalize_path directory in
-    let directory_name =
-      if root_directory = "" || root_directory = "." then
-        Lm_unix_util.temporary_directory prefix suffix
-      else
-        Lm_unix_util.temporary_directory ~root_directory prefix suffix
-    in
+    let directory_name = if root_directory = "" || root_directory = "."
+                         then Lm_unix_util.temporary_directory prefix suffix
+                         else Lm_unix_util.temporary_directory ~root_directory prefix suffix in
       Omake_value_type.ValDir (Omake_env.venv_intern_dir venv directory_name)
 
 (*
@@ -192,7 +184,7 @@ let tmpdir venv pos loc args : Omake_value_type.t =
  *)
 let tmpfile venv pos loc args : Omake_value_type.t =
   let pos' = string_pos "tmpfile" pos in
-  let prefix, suffix, directory =
+  let prefix, suffix, temp_dir =
     match args with
     | [prefix] ->
        Omake_value.string_of_value venv pos' prefix,
@@ -210,14 +202,10 @@ let tmpfile venv pos loc args : Omake_value_type.t =
        raise (Omake_value_type.OmakeException (loc_pos loc pos',
                                                ArityMismatch (ArityRange (1, 3), List.length args)))
   in
-    let temp_dir = canonicalize_path directory in
-    let filename =
-      if temp_dir = "" || temp_dir = "." then
-        Filename.temp_file prefix suffix
-      else
-        Filename.temp_file ~temp_dir prefix suffix
-    in
-    Omake_value_type.ValNode (Omake_env.venv_intern venv PhonyProhibited filename)
+    let filename = if temp_dir = "" || temp_dir = "."
+                   then Filename.temp_file prefix suffix
+                   else Filename.temp_file ~temp_dir prefix suffix in
+      Omake_value_type.ValNode (Omake_env.venv_intern venv PhonyProhibited filename)
 
 (*
  * Display something from a different directory.

--- a/src/libmojave/lm_unix_util.mli
+++ b/src/libmojave/lm_unix_util.mli
@@ -23,6 +23,11 @@ val really_read : Unix.file_descr -> bytes -> int -> int -> unit
 val copy_file : string -> string -> int -> unit
 
 (*
+ * Create a temporary directory.
+ *)
+val temporary_directory: ?root_directory:string -> string -> string -> string
+
+(*
  * Make all the directories in a path.
  *)
 val mkdirhier : string -> unit


### PR DESCRIPTION
Function ``tmpdir`` complements ``tmpfile`` as it sometimes is
more straightforward to create one temporary directory and
use it for many files (with fixed names) than pollute a root
temporary directory with loads of weirdo-named temporary
files.  Cleaning up at the end also is easier with a directory.

