### PR TITLE
Build with -strict-sequence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OCAML = ocaml
-OCAMLFLAGS = -safe-string
+OCAMLFLAGS = -safe-string -strict-sequence
 
 .PHONY: all bootstrap force-bootstrap install default clean doc package
 

--- a/OMakefile
+++ b/OMakefile
@@ -73,7 +73,7 @@ SCANNER_MODE = error
 #
 # OCaml options
 #
-OCAMLFLAGS[] = -safe-string -g -w -a-40
+OCAMLFLAGS[] = -safe-string -strict-sequence -g -w -a-40
 if $(THREADS_ENABLED)
     OCAMLFLAGS += -thread
     export

--- a/mk/osconfig_mingw.mk
+++ b/mk/osconfig_mingw.mk
@@ -31,7 +31,7 @@ EXT_LIB = .a
 EXE = .exe
 CCOMPTYPE = cc
 
-OCAMLFLAGS = -safe-string -thread -w +a-4-32-30-42-40-41-48-50-52-60 -g $(OCAMLFLAGS_EXTRA)
+OCAMLFLAGS = -safe-string -strict-sequence -thread -w +a-4-32-30-42-40-41-48-50-52-60 -g $(OCAMLFLAGS_EXTRA)
 THREADSLIB = threads.cma
 THREADSLIB_OPT = threads.cmxa
 PREFERRED = .byte

--- a/mk/osconfig_msvc.mk
+++ b/mk/osconfig_msvc.mk
@@ -33,7 +33,7 @@ EXE = .exe
 CCOMPTYPE = msvc
 STDLIB := $(shell $(OCAMLC) -where)
 
-OCAMLFLAGS = -safe-string -thread -w +a-4-32-30-42-40-41-48-50-52-60 -g $(OCAMLFLAGS_EXTRA)
+OCAMLFLAGS = -safe-string -strict-sequence -thread -w +a-4-32-30-42-40-41-48-50-52-60 -g $(OCAMLFLAGS_EXTRA)
 THREADSLIB = threads.cma
 THREADSLIB_OPT = threads.cmxa
 PREFERRED = .byte

--- a/mk/osconfig_unix.mk
+++ b/mk/osconfig_unix.mk
@@ -31,7 +31,7 @@ EXT_LIB = .a
 EXE =
 CCOMPTYPE = cc
 
-OCAMLFLAGS = -safe-string -g -w -40 $(OCAMLFLAGS_EXTRA)
+OCAMLFLAGS = -safe-string -strict-sequence -g -w -40 $(OCAMLFLAGS_EXTRA)
 THREADSLIB =
 THREADSLIB_OPT =
 PREFERRED = .byte

--- a/src/build/omake_build_util.mli
+++ b/src/build/omake_build_util.mli
@@ -97,7 +97,7 @@ val command_list_head : Omake_build_type.t ->
   Omake_build_type.command_tag -> Omake_build_type.command
 
 val command_iter : Omake_build_type.t ->
-  Omake_build_type.command_tag -> (Omake_build_type.command -> 'a) -> unit
+  Omake_build_type.command_tag -> (Omake_build_type.command -> unit) -> unit
 
 val command_list_is_empty : Omake_build_type.t -> Omake_build_type.command_tag -> bool
 

--- a/src/libmojave/lm_string_util.mli
+++ b/src/libmojave/lm_string_util.mli
@@ -254,8 +254,8 @@ val encode_hex_name : string -> string
 
 val fold_left : ('a -> char -> 'a) -> 'a -> string -> 'a
 val fold_lefti : ('a -> int -> char -> 'a) -> 'a -> string -> 'a
- 
+
 val fold_right : (char -> 'a -> 'a) -> string -> 'a -> 'a
 val fold_righti : (int -> char -> 'a -> 'a) -> string -> 'a -> 'a
 
-val iteri : (int -> char -> 'a) -> string -> unit
+val iteri : (int -> char -> unit) -> string -> unit

--- a/src/libmojave/lm_thread_sig.ml
+++ b/src/libmojave/lm_thread_sig.ml
@@ -89,7 +89,7 @@ sig
    type id
 
    val enabled : bool
-   val create : ('a -> 'b) -> 'a -> t
+   val create : ('a -> unit) -> 'a -> t
    val self : unit -> t
    val join : t -> unit
    val id : t -> int

--- a/src/libmojave/lm_unix_util.mli
+++ b/src/libmojave/lm_unix_util.mli
@@ -84,7 +84,7 @@ val flock : Unix.file_descr -> flock_command -> unit
  *)
 val getpwents : unit -> Unix.passwd_entry list
 
-val finally : 'a -> ('a -> 'b) -> ('a -> 'c) -> 'b
+val finally : 'a -> ('a -> 'b) -> ('a -> unit) -> 'b
 
 (** TODO: flags need to be documented *)
 val with_file_fmt : string -> (Format.formatter -> 'a) -> 'a


### PR DESCRIPTION
This PR enables -strict-sequence and allows building omake with it enabled.
This is motivated by the proposal of enabling -strict-sequence by default in ocaml/ocaml#1971, in order to make omake forward compatible.