### PR TITLE
Get vmount dependencies right

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -560,14 +560,14 @@ if you really want to build this file.
             raise $(err)
         elseif $(target-exists %.mli)
             %.cmx %$(EXT_OBJ): %.ml %.cmi :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -c $<
+                $(OCamlOpt) -o $@ -c $<
         elseif $(BYTE_ENABLED)
             %.cmx %.cmi %$(EXT_OBJ) %.cmo: %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlC) -c $<
-                $(OCamlOpt) -c $<
+                $(OCamlC) -o $@ -c $<
+                $(OCamlOpt) -o $(replacesuffixes .cmx, $(EXT_OBJ), $@) -c $<
         else
             %.cmx %.cmi %$(EXT_OBJ): %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -c $<
+                $(OCamlOpt) -o $@ -c $<
 
 %$(EXT_OBJ): %.ml
     section rule
@@ -583,14 +583,14 @@ if you really want to build this file.
             raise $(err)
         elseif $(target-exists %.mli)
             %$(EXT_OBJ) %.cmx: %.ml %.cmi :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -c $<
+                $(OCamlOpt) -o $@ -c $<
         elseif $(BYTE_ENABLED)
             %$(EXT_OBJ) %.cmi %.cmx %.cmo: %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlC) -c $<
-                $(OCamlOpt) -c $<
+                $(OCamlC) -o $(replacesuffixes $(EXT_OBJ), .cmo, $@) -c $<
+                $(OCamlOpt) -o $@ -c $<
         else
             %$(EXT_OBJ) %.cmi %.cmx: %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -c $<
+                $(OCamlOpt) -o $@ -c $<
 
 # This is an experimental rule
 %.i.mli: %.ml
@@ -611,31 +611,31 @@ if you really want to build this file.
             raise $(err)
         elseif $(target-exists %.mli)
             %.cmo: %.ml %.cmi :scanner: scan-ocaml-%.ml
-                $(OCamlC) -c $<
+                $(OCamlC) -o $@ -c $<
         elseif $(NATIVE_ENABLED)
             %.cmo %.cmi %.cmx %$(EXT_OBJ): %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlC) -c $<
-                $(OCamlOpt) -c $<
+                $(OCamlC) -o $@ -c $<
+                $(OCamlOpt) -o $(replacesuffixes .cmo, .cmx, $@) -c $<
         else
             %.cmo %.cmi: %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlC) -c $<
+                $(OCamlC) -o $@ -c $<
 
 %.cmi: %.ml
     section rule
         if $(BYTE_ENABLED)
             if $(NATIVE_ENABLED)
                 %.cmi %.cmo %.cmx %$(EXT_OBJ): %.ml :scanner: scan-ocaml-%.ml
-                    $(OCamlC) -c $<
-                    $(OCamlOpt) -c $<
+                    $(OCamlC) -o $@ -c $<
+                    $(OCamlOpt) -o $(replacesuffixes .cmi, .cmx, $@) -c $<
             else
                 %.cmi %.cmo: %.ml :scanner: scan-ocaml-%.ml
-                    $(OCamlC) -c $<
+                    $(OCamlC) -o $@ -c $<
         else
             %.cmi %.cmx %$(EXT_OBJ): %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -c $<
+                $(OCamlOpt) -o $@ -c $<
 
 %.cmi: %.mli :scanner: scan-ocaml-%.mli
-    $(OCamlC) -c $<
+    $(OCamlC) -o $@ -c $<
 
 # \begin{doc}
 # \fun{DeclareMLIOnly}
@@ -658,19 +658,19 @@ DeclareMLIOnly(modules) =
     foreach(mod => ..., $(modules))
         if $(BYTE_ENABLED)
             if $(NATIVE_ENABLED)
-               $(mod).cmi $(mod).cmo $(mod).cmx $(mod).o: $(mod).mli
-                   $(OCamlC) -c $(mod).mli
-                   $(OCamlC) -c -impl $(mod).mli
-                   $(OCamlOpt) -c -impl $(mod).mli
+               $(mod).cmi $(mod).cmo $(mod).cmx $(mod)$(EXT_OBJ): $(mod).mli
+                   $(OCamlC) -o $@ -c $(mod).mli
+                   $(OCamlC) -o $(replacesuffixes .cmi, .cmo, $@) -c -impl $(mod).mli
+                   $(OCamlOpt) -o $(replacesuffixes .cmi, .cmx, $@) -c -impl $(mod).mli
             else
                $(mod).cmi $(mod).cmo: $(mod).mli
-                   $(OCamlC) -c $(mod).mli
-                   $(OCamlC) -c -impl $(mod).mli
+                   $(OCamlC) -o $@ -c $(mod).mli
+                   $(OCamlC) -o $(replacesuffixes .cmi, .cmo, $@) -c -impl $(mod).mli
         else
-           $(mod).cmi $(mod).cmx $(mod).o: $(mod).mli
-               $(OCamlC) -c $(mod).mli
-               $(OCamlOpt) -c -impl $(mod).mli
-        
+           $(mod).cmi $(mod).cmx $(mod)$(EXT_OBJ): $(mod).mli
+               $(OCamlC) -o $@ -c $(mod).mli
+               $(OCamlOpt) -o $(replacesuffixes .cmi, .cmx, $@) -c -impl $(mod).mli
+
 
 ########################################################################
 # Parser generators

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -493,10 +493,19 @@ public.OCamlScannerPostproc(input) =
     #
     protected.filename =
     protected.modules[] =
+    protected.vmounts = $(vmount-map)
+    protected.vmount_source_dirs = $(vmounts)
+    protected.compare_by_length_descending(a, b) =
+        delta_length = $(sub $(b.length), $(a.length))
+        value $(if $(eq $(delta_length), $(int 0)), $(compare $a, $b), $(delta_length))
+    protected.sorted_vmount_source_dirs = $(vmount_source_dirs.sort $(compare_by_length_descending))
     awk(b, $(input))
     case $'^\(.*\):[[:space:]]*\(.*\)$'
         PrintDependencies($(filename), $(modules))
         filename = $1
+        sorted_vmount_source_dirs.foreach(src) =>
+            filename = $(subst $(src), $(vmounts.find $(src)), $(filename))
+            export
         modules[] = $(split $' ', $2)
         export
     case $'^	\(.*\)'

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -226,6 +226,10 @@ public.OCAMLOPTLINK = $`(OCAMLOPT)
 # Include path
 #
 public.OCAMLINCLUDES[] = .
+section
+        vmounts = $(vmount-map)
+        OCAMLINCLUDES[] += $(vmounts.keys)
+        export OCAMLINCLUDES
 public.OCAMLINCLUDES_FOR_OCAMLDEP_MODULES[] = .
 public.PREFIXED_OCAMLINCLUDES = $`(mapprefix -I, $(OCAMLINCLUDES))
 

--- a/src/builtin/omake_builtin_file.ml
+++ b/src/builtin/omake_builtin_file.ml
@@ -2802,6 +2802,37 @@ let vmount venv pos loc args kargs =
 
 (*
  * \begin{doc}
+ * \fun{vmount-map}
+ *
+ * \begin{verbatim}
+ *     vmount-map() : Map
+ * \end{verbatim}
+ *
+ * Answer a Map object with the currently active virtual mounts.
+ * \end{doc}
+ *)
+
+let vmount_table venv pos loc args =
+  let pos = string_pos "vmount-map" pos in
+    if args = [] then
+      let table = List.fold_left
+                    (fun partial_table (dest, src) ->
+                      (* Note that we swap source and destination here
+                       * to generate a map from the source directories
+                       * to the destination ("build") directories. *)
+                      Omake_env.venv_map_add partial_table pos (ValDir src) (ValDir dest))
+                    Omake_env.venv_map_empty
+                    (Omake_env.venv_get_mount_listing venv)
+      in
+        Omake_value_type.ValObject (Omake_env.venv_add_field_internal
+                                      (Omake_env.venv_find_object_or_empty venv Omake_var.map_object_var)
+                                      Omake_symbol.map_sym
+                                      (ValMap table))
+    else
+      raise (Omake_value_type.OmakeException (loc_pos loc pos, ArityMismatch (ArityExact 0, List.length args)))
+
+(*
+ * \begin{doc}
  * \fun{add-project-directories}
  *
  * \begin{verbatim}
@@ -2916,7 +2947,8 @@ let () =
      true, "find-ocaml-targets-in-path-optional", find_ocaml_targets_in_path_optional, ArityExact 2;
 
      true, "add-project-directories", add_project_directories,  ArityExact 1;
-     true, "remove-project-directories", remove_project_directories,  ArityExact 1] in
+     true, "remove-project-directories", remove_project_directories,  ArityExact 1;
+     true, "vmount-map",              vmount_table,             ArityExact 0] in
   let builtin_kfuns =
     [true, "vmount",                  vmount,                   Omake_ir.ArityRange (2, 3);
     ]

--- a/src/env/omake_env.ml
+++ b/src/env/omake_env.ml
@@ -331,6 +331,8 @@ module IntTable = Lm_map.LmMake (IntCompare);;
 let venv_globals venv =
    venv.venv_inner.venv_globals
 
+let venv_get_mount_listing venv =
+  Omake_node.Mount.mount_listing venv.venv_inner.venv_mount
 
 let venv_protect globals f =
   Lm_thread.Mutex.lock globals.venv_mutex;

--- a/src/env/omake_env.mli
+++ b/src/env/omake_env.mli
@@ -360,6 +360,8 @@ val venv_find_field_internal_exn  : Omake_value_type.obj -> Omake_ir.var -> Omak
 val venv_defined_field_internal   : Omake_value_type.obj -> Omake_ir.var -> bool
 val venv_object_fold_internal     : ('a -> Omake_ir.var -> Omake_value_type.t -> 'a) -> 'a -> Omake_value_type.obj -> 'a
 
+val venv_get_mount_listing    : t -> (Omake_node.Dir.t * Omake_node.Dir.t) list
+
 val venv_add_included_file    : t -> Omake_node.Node.t -> t
 val venv_is_included_file     : t -> Omake_node.Node.t -> bool
 val venv_find_ir_file_exn     : t -> Omake_node.Node.t -> Omake_ir.t

--- a/src/ir/omake_node.ml
+++ b/src/ir/omake_node.ml
@@ -1098,6 +1098,10 @@ struct
    (*     Add a mount point. *)
    let mount info options dir_src dir_dst =
       (dir_dst, dir_src, options) :: info
+
+   (* Retrieve an association list of all mounts. *)
+   let mount_listing info =
+     List.map (fun (dir_dst, dir_src, _opt) -> dir_dst, dir_src) info
 end;;
 
 

--- a/src/ir/omake_node_sig.ml
+++ b/src/ir/omake_node_sig.ml
@@ -93,6 +93,11 @@ sig
     *       copy: if true, auto-copy the files from the source to the target
     *)
    val mount : t -> mount_option list -> dir -> dir -> t
+
+   (*
+    * Get the mount table.
+    *)
+   val mount_listing : t -> (dir * dir) list
 end
 
 (*

--- a/src/libmojave/lm_string_util.ml
+++ b/src/libmojave/lm_string_util.ml
@@ -84,6 +84,55 @@ let strchr s c =
   aux 0
 
  (*
+* Find a string in a another string starting at a given index.
+*)
+let string_index_from_opt a_haystack an_initial_index a_needle =
+  let rec is_prefix index_needle index_haystack =
+    index_needle < 0 ||
+      Char.equal (String.unsafe_get a_needle index_needle) (String.unsafe_get a_haystack index_haystack) &&
+        is_prefix (pred index_needle) (pred index_haystack) in
+    let length_haystack = String.length a_haystack
+    and pred_length_needle = pred (String.length a_needle) in
+      let rec search index_needle =
+        let index_haystack = an_initial_index + index_needle + pred_length_needle in
+          if index_haystack >= length_haystack then
+            None
+          else if is_prefix pred_length_needle index_haystack then
+            Some (an_initial_index + index_needle)
+          else
+            search (succ index_needle)
+      in
+        search 0
+
+ (*
+* Find/replace matching prefix in a string
+*)
+let substitute_prefix a_prefix a_replacement a_text =
+  match string_index_from_opt a_text 0 a_prefix with
+    None -> a_text
+  | Some _index ->
+     let length_prefix = String.length a_prefix in
+       a_replacement ^ String.sub a_text length_prefix (String.length a_text - length_prefix)
+
+ (*
+* Find/replace all occurrences in a string
+*)
+let substitute_all a_search_text a_replacement a_text =
+  let length_search_text = String.length a_search_text
+  and result = Buffer.create (String.length a_text) in
+    let rec replace_at initial_index =
+      match string_index_from_opt a_text initial_index a_search_text with
+        None ->
+         Buffer.add_substring result a_text initial_index (String.length a_text - initial_index)
+      | Some index ->
+         Buffer.add_substring result a_text initial_index (index - initial_index);
+         Buffer.add_string result a_replacement;
+         replace_at (index + length_search_text)
+    in
+      replace_at 0;
+      Buffer.contents result
+
+ (*
  * A more efficient reimplementation of String.contains.
 *)
 let contains =

--- a/src/libmojave/lm_string_util.mli
+++ b/src/libmojave/lm_string_util.mli
@@ -33,6 +33,12 @@ val unhexify_int : string -> int
 val strchr : string -> char -> int
 
 (*
+ * Find/replace in a string
+ *)
+val substitute_prefix : string -> string -> string -> string
+val substitute_all : string -> string -> string -> string
+
+(*
  * Membership.
  *    contains s c : true iff c appears in s
  *    contains_string s1 s2 : true iff any char in s2 appears in s1


### PR DESCRIPTION
The OCaml build rules coded in _OCaml.om_ do not honor vmounted-directories.
This pull-request fixes this problem and in turn adds two useful user functions:
  - `$(subst FROM, TO, TEXT)`: literally replace text;
  - `$(vmount-map)`: answer the current vmounts;
