### PR TITLE
New target-generation functions: `OCamlMixedLibrary` and `OCamlMixedProgram`.

### DIFF
--- a/doc/src/omake-build-examples.tex
+++ b/doc/src/omake-build-examples.tex
@@ -320,7 +320,8 @@ option \verb+-inline 10+, but files in \verb+my_project/src/lib+ are compiled no
 
 \section{OCaml~Library with C~Dependencies}
 
-Build an OCaml~library that depends on both, OCaml~code and C~code.
+Build the OCaml~library~\verb+libstring_extra+, which depends on both,
+OCaml~code and C~code.
 
 \begin{verbatim}
     lib/
@@ -330,39 +331,49 @@ Build an OCaml~library that depends on both, OCaml~code and C~code.
     |---> index_from_opt_interface.c
 \end{verbatim}
 
-The example \verb+libstring_extra+ defines the single
-function~\verb+index_from_opt+, which searches for the
-string~\verb+a_needle+ in the string~\verb+a_haystack+ starting at
-\verb+an_initial_index+ in \verb+a_haystack+; it returns \verb+None+
-if \verb+a_needle+ was not found or \verb+Some index+, where
-\verb+index+ is the starting index of \verb+a_needle+ in
-\verb+a_haystack+ (after \verb+an_initial_index+).
-
 This is the OCaml interface file~\verb+string_extra.mli+:
 
 \begin{verbatim}
-(** [index_from_opt a_haystack an_initial_index a_needle] *)
-external index_from_opt: string -> int -> string -> int option = "index_from_opt_interface"
+(** [index_from_opt a_haystack an_initial_index a_needle]
+ *  @raise Invalid_argument if the initial index is out of range. *)
+val index_from_opt: string -> int -> string -> int option
+
+(** [index_from a_haystack an_initial_index a_needle]
+ *  @raise Invalid_argument if the initial index is out of range.
+ *  @raise Not_found if there is no needle in haystack after the initial index. *)
+val index_from: string -> int -> string -> int
 \end{verbatim}
 
-In our example the OCaml code file~\verb+string_extra.ml+ has the same
-contents as the interface file.
+The associated OCaml code file~\verb+string_extra.ml+ looks like this:
+
+\begin{verbatim}
+external index_from_opt: string -> int -> string -> int option = "index_from_opt_interface"
+
+let index_from a_haystack an_initial_index a_needle =
+  match index_from_opt a_haystack an_initial_index a_needle with
+    None -> raise Not_found
+  | Some index -> index
+\end{verbatim}
 
 The C~code in \verb+index_from_opt_interface.c+ is gross because we
-want to play nice with OCaml's garbage collector.  Note that we must
-use function~\verb+memmem+ of the GNU C-library, because OCaml~strings
-are not null-terminated.
+must play nice with OCaml's garbage collector.  We use
+function~\verb+memmem+ of the GNU~C-library because OCaml~strings are
+not null-terminated.
 
 \begin{verbatim}
 #define _GNU_SOURCE           /* Pull memmem(3) into scope. */
+#include <string.h>           /* NULL, size_t; _GNU_SOURCE: memmem() */
 
-#include <string.h>           /* _GNU_SOURCE: memmem() */
-
+#define CAML_NAME_SPACE       /* Only define objects with "caml_" prefix. */
 #include <caml/alloc.h>       /* caml_alloc() */
-#include <caml/memory.h>      /* CAMLlocal1(), CAMLparam1(), CAMLparam3() */
-#include <caml/mlvalues.h>    /* value */
+#include <caml/fail.h>        /* caml_invalid_argument() */
+#include <caml/memory.h>      /* CAMLlocal1(), CAMLparam1(), CAMLparam3(),
+                               * CAMLreturn(), Store_field() */
+#include <caml/mlvalues.h>    /* Long_val(), String_val(), Val_int(),
+                               * caml_string_length(), value */
 
 #define Val_none Val_int(0)
+
 
 inline static
 value
@@ -377,19 +388,31 @@ Val_some(value a_value)
     CAMLreturn(some);
 }
 
-CAMLprim value
+
+CAMLprim
+value
 index_from_opt_interface(value a_haystack, value an_initial_index, value a_needle)
 {
     CAMLparam3(a_haystack, an_initial_index, a_needle);
 
     const char *const haystack = String_val(a_haystack);
-    const size_t initial_index = (size_t) Long_val(an_initial_index);
-    const char *const index = memmem(haystack + initial_index,
-                                     caml_string_length(a_haystack) - initial_index,
-                                     String_val(a_needle),
-                                     caml_string_length(a_needle));
+    const size_t haystack_length = caml_string_length(a_haystack);
+    const long initial_index = Long_val(an_initial_index);
 
-    CAMLreturn((index == NULL) ? Val_none : Val_some(Val_int(index - haystack)));
+    if (initial_index >= 0L && (size_t) initial_index < haystack_length)
+    {
+        const char *const index =
+             memmem(haystack + initial_index,
+                    caml_string_length(a_haystack) - (size_t) initial_index,
+                    String_val(a_needle),
+                    caml_string_length(a_needle));
+
+        CAMLreturn((index == NULL) ? Val_none : Val_some(Val_int(index - haystack)));
+    }
+    else
+    {
+        caml_invalid_argument("index_from_opt_interface");
+    }
 }
 \end{verbatim}
 

--- a/doc/src/omake-build-examples.tex
+++ b/doc/src/omake-build-examples.tex
@@ -260,10 +260,10 @@ The listing is only a bit different.
 my_project/OMakeroot:
     # Include the standard configuration for OCaml applications
     open build/OCaml
-    
+
     # Process the command-line vars
     DefineCommandVars()
-    
+
     # Include the OMakefile in this directory.
     .SUBDIRS: .
 
@@ -317,6 +317,94 @@ my_project/src/main/OMakefile:
 In this case, most of the configuration here is defined in the file \verb+build/OCaml.om+.  In this
 particular configuration, files in \verb+my_project/src/lib+ are compiled aggressively with the
 option \verb+-inline 10+, but files in \verb+my_project/src/lib+ are compiled normally.
+
+\section{OCaml~Library with C~Dependencies}
+
+Build an OCaml~library that depends on both, OCaml~code and C~code.
+
+\begin{verbatim}
+    lib/
+    |---> OMakefile
+    |---> string_extra.mli
+    |---> string_extra.ml
+    |---> index_from_opt_interface.c
+\end{verbatim}
+
+The example \verb+libstring_extra+ defines the single
+function~\verb+index_from_opt+, which searches for the
+string~\verb+a_needle+ in the string~\verb+a_haystack+ starting at
+\verb+an_initial_index+ in \verb+a_haystack+; it returns \verb+None+
+if \verb+a_needle+ was not found or \verb+Some index+, where
+\verb+index+ is the starting index of \verb+a_needle+ in
+\verb+a_haystack+ (after \verb+an_initial_index+).
+
+This is the OCaml interface file~\verb+string_extra.mli+:
+
+\begin{verbatim}
+(** [index_from_opt a_haystack an_initial_index a_needle] *)
+external index_from_opt: string -> int -> string -> int option = "index_from_opt_interface"
+\end{verbatim}
+
+In our example the OCaml code file~\verb+string_extra.ml+ has the same
+contents as the interface file.
+
+The C~code in \verb+index_from_opt_interface.c+ is gross because we
+want to play nice with OCaml's garbage collector.  Note that we must
+use function~\verb+memmem+ of the GNU C-library, because OCaml~strings
+are not null-terminated.
+
+\begin{verbatim}
+#define _GNU_SOURCE           /* Pull memmem(3) into scope. */
+
+#include <string.h>           /* _GNU_SOURCE: memmem() */
+
+#include <caml/alloc.h>       /* caml_alloc() */
+#include <caml/memory.h>      /* CAMLlocal1(), CAMLparam1(), CAMLparam3() */
+#include <caml/mlvalues.h>    /* value */
+
+#define Val_none Val_int(0)
+
+inline static
+value
+Val_some(value a_value)
+{
+    CAMLparam1(a_value);
+    CAMLlocal1(some);
+
+    some = caml_alloc(1, 0);
+    Store_field(some, 0, a_value);
+
+    CAMLreturn(some);
+}
+
+CAMLprim value
+index_from_opt_interface(value a_haystack, value an_initial_index, value a_needle)
+{
+    CAMLparam3(a_haystack, an_initial_index, a_needle);
+
+    const char *const haystack = String_val(a_haystack);
+    const size_t initial_index = (size_t) Long_val(an_initial_index);
+    const char *const index = memmem(haystack + initial_index,
+                                     caml_string_length(a_haystack) - initial_index,
+                                     String_val(a_needle),
+                                     caml_string_length(a_needle));
+
+    CAMLreturn((index == NULL) ? Val_none : Val_some(Val_int(index - haystack)));
+}
+\end{verbatim}
+
+The \verb+OMakefile+ however is very simple; we just have to add the
+path to the OCaml~compiler's interface files to \verb+CFLAGS+.
+
+\begin{verbatim}
+OCAMLFLAGS = -g -strict-formats -strict-sequence -w +a
+CFLAGS = -O2 -g -Wall -Wextra -Wconversion -I$(OCAMLLIB)
+
+OCamlMixedLibrary(libstring_extra, string_extra, index_from_opt_interface)
+\end{verbatim}
+
+To use the library put \verb+OCAML_LIBS = libstring_extra+ in the
+relevant \verb+OMakefile+.
 
 \section{Handling new languages}
 \index{cats and dogs}

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -880,9 +880,10 @@ OCamlLinkSort(nodes) =
 # Generic rule to build an ML library
 #
 # \begin{doc}
+# \subsection{Building OCaml programs and Libraries}
 # \fun{OCamlLibrary}
 #
-# The \verb+OCamlLibrary+ function builds an OCaml library.
+# The \verb+OCamlLibrary+ function builds an OCaml~library.
 #
 # \verb+OCamlLibrary(<libname>, <files>)+
 #
@@ -899,49 +900,121 @@ OCamlLinkSort(nodes) =
 # OCamlLibrary(libfoo, foo bar)
 # \end{verbatim}
 #
-# If the variable \verb+CMXS_ENABLED+ is set, additionally the cmxs plugin
-# is created. Note that \verb+CMXS_SUPPORTED+ returns whether the compiler
+# If the variable \verb+CMXS_ENABLED+ is set, additionally the cmxs~plugin
+# is created.  Note that \verb+CMXS_SUPPORTED+ returns whether the compiler
 # installation supports plugins, so you can simply set
 #
 # \begin{verbatim}
 # CMXS_ENABLED = CMXS_SUPPORTED
 # \end{verbatim}
 #
-# before calling \verb+OCamlLibrary+. For compatibility with older omake
+# before calling \verb+OCamlLibrary+.  For compatibility with older omake
 # versions, \verb+CMXS_ENABLED+ defaults to \verb+false+.
 # \end{doc}
 #
-public.OCamlLibrary(name, files) =
-   # XXX: JYH: these variables should be marked private in 0.9.9
-   protected.name = $(file $(name))
+public.OCamlLibrary(library_name, ocaml_module_names) =
+        # XXX: JYH: these variables should be marked private in 0.9.9
+        protected.LIBRARY_NAME = $(file $(library_name))
 
-   protected.OFILES   = $(addsuffix $(EXT_OBJ), $(files))
-   protected.CMOFILES = $(addsuffix .cmo, $(files))
-   protected.CMXFILES = $(addsuffix .cmx, $(files))
+        protected.OFILES = $(addsuffix $(EXT_OBJ), $(ocaml_module_names))
+        protected.CMOFILES = $(addsuffix .cmo, $(ocaml_module_names))
+        protected.CMXFILES = $(addsuffix .cmx, $(ocaml_module_names))
 
-   protected.CLIB      = $(file $(name)$(EXT_LIB))
-   protected.BYTELIB   = $(file $(name).cma)
-   protected.NATIVELIB = $(file $(name).cmxa)
-   protected.SHAREDLIB = $(file $(name).cmxs)
+        protected.CLIB = $(file $(LIBRARY_NAME)$(EXT_LIB))
+        protected.BYTELIB = $(file $(LIBRARY_NAME).cma)
+        protected.NATIVELIB = $(file $(LIBRARY_NAME).cmxa)
+        protected.SHAREDLIB = $(file $(LIBRARY_NAME).cmxs)
 
-   #
-   # Link commands
-   #
-   $(BYTELIB): $(CMOFILES)
-        $(OCAMLFIND) $(OCAMLLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS) $(OCAMLFLAGS) $(OCAMLCFLAGS) \
-                $(OCAML_LIB_FLAGS) -a -o $@ $(OCamlLinkSort $(CMOFILES))
+        #
+        # Link commands
+        #
+        $(BYTELIB): $(CMOFILES)
+                $(OCAMLFIND) $(OCAMLLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                          $(OCAMLFLAGS) $(OCAMLCFLAGS)  \
+                                          $(OCAML_LIB_FLAGS) -a  \
+                                          -o $@  \
+                                          $(OCamlLinkSort $(CMOFILES))
 
-   $(NATIVELIB) $(CLIB): $(CMXFILES) $(OFILES)
-        $(OCAMLFIND) $(OCAMLOPTLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS) $(OCAMLFLAGS) $(OCAMLOPTFLAGS) \
-                $(OCAML_LIB_FLAGS) -a -o $(NATIVELIB) $(OCamlLinkSort $(CMXFILES))
+        $(NATIVELIB) $(CLIB): $(CMXFILES) $(OFILES)
+                $(OCAMLFIND) $(OCAMLOPTLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                             $(OCAMLFLAGS) $(OCAMLOPTFLAGS)  \
+                                             $(OCAML_LIB_FLAGS) -a  \
+                                             -o $(NATIVELIB)  \
+                                             $(OCamlLinkSort $(CMXFILES))
 
-   $(SHAREDLIB): $(NATIVELIB) $(CLIB)
-      $(OCAMLFIND) $(OCAMLOPTLINK) -shared -cclib -L. -o $(SHAREDLIB) $(NATIVELIB)
+        $(SHAREDLIB): $(NATIVELIB) $(CLIB)
+                $(OCAMLFIND) $(OCAMLOPTLINK) -shared -cclib -L. -o $@ $(NATIVELIB)
 
-   return $(array $(if $(NATIVE_ENABLED), $(NATIVELIB)), $(if $(NATIVE_ENABLED), $(CLIB)), $(if $(BYTE_ENABLED), $(BYTELIB)), $(if $(CMXS_ENABLED), $(SHAREDLIB)))
+        return $(array $(if $(NATIVE_ENABLED), $(NATIVELIB)),  \
+                       $(if $(NATIVE_ENABLED), $(CLIB)),  \
+                       $(if $(BYTE_ENABLED), $(BYTELIB)),  \
+                       $(if $(CMXS_ENABLED), $(SHAREDLIB)))
 
 #
-# Generic rule to build an ML library
+# Generic rule to build an ML library that also depends on foreign (e.g. C) objects
+#
+# \begin{doc}
+# \fun{OCamlMixedLibrary}
+#
+# The \verb+OCamlMixedLibrary+ function builds an OCaml~library from
+# ML~files and foreign objects.
+#
+# \verb+OCamlMixedLibrary(<libname>, <ml-files>, <foreign-files>)+
+#
+# It is particularly useful if one or more ml-files contain
+# \verb+external+~definitions that are satisifed by the foreign-files.
+# It works similarly to \verb+OCamlLibrary+, but also
+# \begin{enumerate}
+#   \item adds dependencies of \verb+<foreign-files>+ to
+#         \verb+<libname>+ and
+#   \item appends all objects defined by \verb+<foreign-files>+ to
+#         \verb+<libname>+.
+# \end{enumerate}
+#
+# The \verb+<libname>+, \verb+<files>+, and \verb+<foreign-files>+ are
+# listed \emph{without} suffixes.
+# \end{doc}
+#
+public.OCamlMixedLibrary(library_name, ocaml_module_names, foreign_module_names) =
+        protected.LIBRARY_NAME = $(file $(library_name))
+
+        protected.OFILES = $(addsuffix $(EXT_OBJ), $(ocaml_module_names))
+        protected.FOREIGN_OFILES = $(addsuffix $(EXT_OBJ), $(foreign_module_names))
+        protected.CMOFILES = $(addsuffix .cmo, $(ocaml_module_names))
+        protected.CMXFILES = $(addsuffix .cmx, $(ocaml_module_names))
+
+        protected.CLIB = $(file $(LIBRARY_NAME)$(EXT_LIB))
+        protected.BYTELIB = $(file $(LIBRARY_NAME).cma)
+        protected.NATIVELIB = $(file $(LIBRARY_NAME).cmxa)
+        protected.SHAREDLIB = $(file $(LIBRARY_NAME).cmxs)
+
+        #
+        # Link commands
+        #
+        $(BYTELIB): $(CMOFILES) $(FOREIGN_OFILES)
+                $(OCAMLFIND) $(OCAMLLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                          $(OCAMLFLAGS) $(OCAMLCFLAGS)  \
+                                          $(OCAML_LIB_FLAGS) -a  \
+                                          -o $@  \
+                                          $(OCamlLinkSort $(CMOFILES)) $(FOREIGN_OFILES)
+
+        $(NATIVELIB) $(CLIB): $(CMXFILES) $(OFILES) $(FOREIGN_OFILES)
+                $(OCAMLFIND) $(OCAMLOPTLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                             $(OCAMLFLAGS) $(OCAMLOPTFLAGS)  \
+                                             $(OCAML_LIB_FLAGS) -a  \
+                                             -o $(NATIVELIB)  \
+                                             $(OCamlLinkSort $(CMXFILES)) $(FOREIGN_OFILES)
+
+        $(SHAREDLIB): $(NATIVELIB) $(CLIB)
+                $(OCAMLFIND) $(OCAMLOPTLINK) -shared -cclib -L. -o $@ $(NATIVELIB)
+
+        return $(array $(if $(NATIVE_ENABLED), $(NATIVELIB)),  \
+                       $(if $(NATIVE_ENABLED), $(CLIB)),  \
+                       $(if $(BYTE_ENABLED), $(BYTELIB)),  \
+                       $(if $(CMXS_ENABLED), $(SHAREDLIB)))
+
+#
+# Generic rule to build an ML package
 #
 # \begin{doc}
 # \fun{OCamlPackage}
@@ -1176,73 +1249,170 @@ public.OCamlLibraryInstall(tag, lib, name, files) =
 # \begin{doc}
 # \fun{OCamlProgram}
 #
-# The \verb+OCamlProgram+ function builds an OCaml program. It returns the array with all
-# the targets for which it has defined the rules (\verb+$(name)$(EXE)+ and \verb+$(name).run+
-# and/or \verb+$(name).opt+, depending on the \verb+NATIVE_ENABLED+ and \verb+BYTE_ENABLED+
-# variables).
+# The \verb+OCamlProgram+~function builds an OCaml~program.  It
+# returns the array with all the targets for which it has defined the
+# rules (\verb+$(name)$(EXE)+ and \verb+$(name).run+ and/or
+# \verb+$(name).opt+, depending on the \verb+NATIVE_ENABLED+ and
+# \verb+BYTE_ENABLED+ variables).
 #
 # \verb+OCamlProgram(<name>, <files>)+
 #
 # Additional variables used:
 # \begin{description}
-# \item[\hypervarxn{OCAML_LIBS}{OCAML\_LIBS}] Additional libraries passed to the linker, without suffix.  These files
+# \item[\hypervarxn{OCAML_LIBS}{OCAML\_LIBS}] Additional libraries
+#    passed to the linker, without suffix.  These files
 #    become dependencies of the target program.
-# \item[\hypervarxn{OCAML_OTHER_LIBS}{OCAML\_OTHER\_LIBS}] Additional libraries passed to the linker, without suffix.  These
+# \item[\hypervarxn{OCAML_OTHER_LIBS}{OCAML\_OTHER\_LIBS}] Additional
+#    libraries passed to the linker, without suffix.  These
 #    files do \emph{not} become dependencies of the target program.
-# \item[\hypervarxn{OCAML_CLIBS}{OCAML\_CLIBS}] C libraries to pass to the linker.
-# \item[\hypervarxn{OCAML_BYTE_LINK_FLAGS}{OCAML\_BYTE\_LINK\_FLAGS}] Flags to pass to the bytecode linker.
-# \item[\hypervarxn{OCAML_NATIVE_LINK_FLAGS}{OCAML\_NATIVE\_LINK\_FLAGS}] Flags to pass to the native code linker.
-# \item[\hypervarxn{OCAML_LINK_FLAGS}{OCAML\_LINK\_FLAGS}] Flags to pass to both linkers.
+# \item[\hypervarxn{OCAML_CLIBS}{OCAML\_CLIBS}] C~libraries to pass to
+#    the linker.
+# \item[\hypervarxn{OCAML_BYTE_LINK_FLAGS}{OCAML\_BYTE\_LINK\_FLAGS}] Flags
+#    to pass to the bytecode~linker.
+# \item[\hypervarxn{OCAML_NATIVE_LINK_FLAGS}{OCAML\_NATIVE\_LINK\_FLAGS}] Flags
+#    to pass to the native-code~linker.
+# \item[\hypervarxn{OCAML_LINK_FLAGS}{OCAML\_LINK\_FLAGS}] Flags to
+#    pass to both linkers.
 # \end{description}
 # \end{doc}
 #
-public.OCamlProgram(name, files) =
-   # XXX: JYH: these variables should be marked private in 0.9.9
-   protected.CMOFILES  = $(addsuffix .cmo, $(files))
-   protected.CMXFILES  = $(addsuffix .cmx, $(files))
-   protected.OFILES    = $(addsuffix $(EXT_OBJ), $(files))
+public.OCamlProgram(program_name, ocaml_module_names) =
+        # XXX: JYH: these variables should be marked private in 0.9.9
+        protected.PROGRAM_NAME = $(file $(program_name))
 
-   protected.CMAFILES  = $(addsuffix .cma,  $(OCAML_LIBS))
-   protected.CMXAFILES = $(addsuffix .cmxa, $(OCAML_LIBS))
-   protected.ARFILES   = $(addsuffix $(EXT_LIB), $(OCAML_LIBS))
-   protected.CMA_OTHER_FILES = $(addsuffix .cma, $(OCAML_OTHER_LIBS))
-   protected.CMXA_OTHER_FILES = $(addsuffix .cmxa, $(OCAML_OTHER_LIBS))
+        protected.CMOFILES = $(addsuffix .cmo, $(ocaml_module_names))
+        protected.CMXFILES = $(addsuffix .cmx, $(ocaml_module_names))
+        protected.OFILES = $(addsuffix $(EXT_OBJ), $(ocaml_module_names))
 
-   protected.CLIBS = $(addsuffix $(EXT_LIB), $(OCAML_CLIBS))
+        protected.CMAFILES = $(addsuffix .cma,  $(OCAML_LIBS))
+        protected.CMXAFILES = $(addsuffix .cmxa, $(OCAML_LIBS))
+        protected.ARFILES = $(addsuffix $(EXT_LIB), $(OCAML_LIBS))
+        protected.CMA_OTHER_FILES = $(addsuffix .cma, $(OCAML_OTHER_LIBS))
+        protected.CMXA_OTHER_FILES = $(addsuffix .cmxa, $(OCAML_OTHER_LIBS))
 
-   protected.name = $(file $(name))
+        protected.CLIBS = $(addsuffix $(EXT_LIB), $(OCAML_CLIBS))
 
-   protected.PROG     = $(file $(name)$(EXE))
-   protected.BYTEPROG = $(file $(name).run)
-   protected.OPTPROG  = $(file $(name).opt)
+        protected.PROGRAM = $(file $(PROGRAM_NAME)$(EXE))
+        protected.BYTEPROGRAM = $(file $(PROGRAM_NAME).run)
+        protected.OPTPROGRAM = $(file $(PROGRAM_NAME).opt)
 
-   #
-   # Rules to build byte-code and native targets
-   #
-   $(BYTEPROG): $(CMAFILES) $(CMOFILES) $(CLIBS)
-        $(OCAMLFIND) $(OCAMLLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS) $(OCAMLFLAGS) $(OCAMLCFLAGS)\
-                $(PREFIXED_OCAMLINCLUDES) $(OCAML_BYTE_LINK_FLAGS)\
-                -o $@ $(CMA_OTHER_FILES) $(CMAFILES) $(OCamlLinkSort $(CMOFILES))\
-                $(CLIBS) $(OCAML_LINK_FLAGS)
+        #
+        # Rules to build byte-code and native targets
+        #
+        $(BYTEPROGRAM): $(CMAFILES) $(CMOFILES) $(CLIBS)
+                $(OCAMLFIND) $(OCAMLLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                          $(OCAMLFLAGS) $(OCAMLCFLAGS)  \
+                                          $(PREFIXED_OCAMLINCLUDES) $(OCAML_BYTE_LINK_FLAGS) \
+                                          -o $@  \
+                                          $(CMA_OTHER_FILES) $(CMAFILES)  \
+                                          $(OCamlLinkSort $(CMOFILES)) \
+                                          $(CLIBS) $(OCAML_LINK_FLAGS)
 
-   $(OPTPROG): $(CMXAFILES) $(ARFILES) $(CMXFILES) $(OFILES) $(CLIBS)
-        $(OCAMLFIND) $(OCAMLOPTLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS) $(OCAMLFLAGS) $(OCAMLOPTFLAGS)\
-                $(PREFIXED_OCAMLINCLUDES) $(OCAML_NATIVE_LINK_FLAGS)\
-                -o $@ $(CMXA_OTHER_FILES) $(CMXAFILES) $(OCamlLinkSort $(CMXFILES))\
-                $(CLIBS) $(OCAML_LINK_FLAGS)
+        $(OPTPROGRAM): $(CMXAFILES) $(ARFILES) $(CMXFILES) $(OFILES) $(CLIBS)
+                $(OCAMLFIND) $(OCAMLOPTLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                             $(OCAMLFLAGS) $(OCAMLOPTFLAGS)  \
+                                             $(PREFIXED_OCAMLINCLUDES) $(OCAML_NATIVE_LINK_FLAGS)  \
+                                             -o $@  \
+                                             $(CMXA_OTHER_FILES) $(CMXAFILES)  \
+                                             $(OCamlLinkSort $(CMXFILES))  \
+                                             $(CLIBS) $(OCAML_LINK_FLAGS)
 
-   #
-   # Link the actual executables.
-   # Always prefer native executables.
-   #
-   if $(NATIVE_ENABLED)
-        $(PROG): $(OPTPROG)
-            ln-or-cp $< $@
-   else
-        $(PROG): $(BYTEPROG)
-            ln-or-cp $< $@
+        #
+        # Link the actual executables.
+        # Always prefer native executables.
+        #
+        if $(NATIVE_ENABLED)
+             $(PROGRAM): $(OPTPROGRAM)
+                 ln-or-cp $< $@
+        else
+             $(PROGRAM): $(BYTEPROGRAM)
+                 ln-or-cp $< $@
 
-   return $(array $(PROG), $(if $(NATIVE_ENABLED), $(OPTPROG)), $(if $(BYTE_ENABLED), $(BYTEPROG)))
+        return $(array $(PROGRAM),  \
+                       $(if $(NATIVE_ENABLED), $(OPTPROGRAM)),  \
+                       $(if $(BYTE_ENABLED), $(BYTEPROGRAM)))
+
+#
+# Generic rule to build an OCaml program that also depends on foreign (e.g. C) objects
+#
+# \begin{doc}
+# \fun{OCamlMixedProgram}
+#
+# The \verb+OCamlMixedProgram+ function builds an OCaml~program from
+# ML files and foreign objects.
+#
+# \verb+OCamlMixedProgram(<programname>, <ml-files>, <foreign-files>)+
+#
+# It is particularly useful if one or more ml-files contain
+# \verb+external+~definitions that are satisifed by the foreign-files.
+# It works similarly to \verb+OCamlProgram+, but also
+# \begin{enumerate}
+#   \item adds dependencies of \verb+<foreign-files>+ to
+#         \verb+<programname>+ and
+#   \item appends all objects defined by \verb+<foreign-files>+ to
+#         \verb+<programname>+.
+# \end{enumerate}
+#
+# The \verb+<programname>+, \verb+<files>+, and \verb+<foreign-files>+ are
+# listed \emph{without} suffixes.
+# \end{doc}
+#
+public.OCamlMixedProgram(program_name, ocaml_module_names, foreign_module_names) =
+        # XXX: JYH: these variables should be marked private in 0.9.9
+        protected.PROGRAM_NAME = $(file $(program_name))
+
+        protected.CMOFILES = $(addsuffix .cmo, $(ocaml_module_names))
+        protected.CMXFILES = $(addsuffix .cmx, $(ocaml_module_names))
+        protected.OFILES = $(addsuffix $(EXT_OBJ), $(ocaml_module_names))
+        protected.FOREIGN_OFILES = $(addsuffix $(EXT_OBJ), $(foreign_module_names))
+
+        protected.CMAFILES = $(addsuffix .cma,  $(OCAML_LIBS))
+        protected.CMXAFILES = $(addsuffix .cmxa, $(OCAML_LIBS))
+        protected.ARFILES = $(addsuffix $(EXT_LIB), $(OCAML_LIBS))
+        protected.CMA_OTHER_FILES = $(addsuffix .cma, $(OCAML_OTHER_LIBS))
+        protected.CMXA_OTHER_FILES = $(addsuffix .cmxa, $(OCAML_OTHER_LIBS))
+
+        protected.CLIBS = $(addsuffix $(EXT_LIB), $(OCAML_CLIBS))
+
+        protected.PROGRAM = $(file $(PROGRAM_NAME)$(EXE))
+        protected.BYTEPROGRAM = $(file $(PROGRAM_NAME).run)
+        protected.OPTPROGRAM = $(file $(PROGRAM_NAME).opt)
+
+        #
+        # Rules to build byte-code and native targets
+        #
+        $(BYTEPROGRAM): $(CMAFILES) $(CMOFILES) $(CLIBS) $(FOREIGN_OFILES)
+                $(OCAMLFIND) $(OCAMLLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                          $(OCAMLFLAGS) $(OCAMLCFLAGS)  \
+                                          $(PREFIXED_OCAMLINCLUDES) $(OCAML_BYTE_LINK_FLAGS) \
+                                          -o $@  \
+                                          $(CMA_OTHER_FILES) $(CMAFILES)  \
+                                          $(OCamlLinkSort $(CMOFILES)) $(FOREIGN_OFILES)  \
+                                          $(CLIBS) $(OCAML_LINK_FLAGS)
+
+        $(OPTPROGRAM): $(CMXAFILES) $(ARFILES) $(CMXFILES) $(OFILES) $(CLIBS) $(FOREIGN_OFILES)
+                $(OCAMLFIND) $(OCAMLOPTLINK) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS)  \
+                                             $(OCAMLFLAGS) $(OCAMLOPTFLAGS)  \
+                                             $(PREFIXED_OCAMLINCLUDES) $(OCAML_NATIVE_LINK_FLAGS)  \
+                                             -o $@  \
+                                             $(CMXA_OTHER_FILES) $(CMXAFILES)  \
+                                             $(OCamlLinkSort $(CMXFILES)) $(FOREIGN_OFILES)  \
+                                             $(CLIBS) $(OCAML_LINK_FLAGS)
+
+        #
+        # Link the actual executables.
+        # Always prefer native executables.
+        #
+        if $(NATIVE_ENABLED)
+             $(PROGRAM): $(OPTPROGRAM)
+                 ln-or-cp $< $@
+        else
+             $(PROGRAM): $(BYTEPROGRAM)
+                 ln-or-cp $< $@
+
+        return $(array $(PROGRAM),  \
+                       $(if $(NATIVE_ENABLED), $(OPTPROGRAM)),  \
+                       $(if $(BYTE_ENABLED), $(BYTEPROGRAM)))
 
 #
 # Copy to $(BIN) directory


### PR DESCRIPTION
The functions mostly duplicate the functionality of `OCamlLibrary` and `OCamlProgram`,
but allow for adding "foreign" dependencies , which usually arise by `external`s
in the ML-code.

This pull request is the follow-up of the discussion in #120.
