### PR TITLE
Clarify native enabled hint

### DIFF
--- a/doc/src/omake-rules.tex
+++ b/doc/src/omake-rules.tex
@@ -154,6 +154,36 @@ if it exists, otherwise \verb+hello.c+ is created from the file \verb+default.c+
                  cp default.c hello.c
 \end{verbatim}
 
+In an implicit rule, any special variables, for example the one for the current target~(\verb+$@+)
+or the first prerequisite~(\verb+$<+) are undefined; substitute \verb+$(file TARGET-PATTERN)+ and
+\verb+$(file SOURCE-PATTERN)+:
+
+\begin{verbatim}
+    %.foo: %.bar
+        section rule
+            println($"target: $(file %.foo)")
+            println($"prereq: $(file %.bar)")
+            /usr/bin/printf "prerequisite was $(file %.bar)\n"  > $(file %.foo)
+\end{verbatim}
+
+However, if the \verb+section rule+ defines its own rule heads, all special variables work as usual
+with respect to their rule heads:
+
+\begin{verbatim}
+    %.cmx: %.ml
+        section rule
+            if $(target-exists %.mli)
+                %.cmx %.o: %.ml %.cmi :scanner: scan-ocaml-%.ml
+                    $(OCamlOpt) -c $<
+            elseif $(BYTE_ENABLED)
+                %.cmx %.cmi %.o %.cmo: %.ml :scanner: scan-ocaml-%.ml
+                    $(OCamlC) -c $<
+                    $(OCamlOpt) -c $<
+            else
+                %.cmx %.cmi %.o: %.ml :scanner: scan-ocaml-%.ml
+                    $(OCamlOpt) -c $<
+\end{verbatim}
+
 \section{Special dependencies}
 \index{rule, options}
 

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -552,15 +552,15 @@ NativeCompilerNotEnabledBuildError. =
 
         new(a_target) =
                 this = $(CompilerNotEnabledBuildError::new $(a_target))
-                lead_in_sencence = $"""You are trying to build OCaml native-code file "$(a_target)"."""
+                lead_in_sentence = $"""You are trying to build OCaml native-code file "$(a_target)"."""
                 if $(OCAMLOPT_EXISTS)
-                        this.message = $"""$(lead_in_sencence)
+                        this.message = $"""$(lead_in_sentence)
 However, the NATIVE_ENABLED flag is not set.
 Include the following definition in the relevant OMakefile:
         NATIVE_ENABLED = true"""
                         return $(this)
                 else
-                        this.message = $"""$(lead_in_sencence)
+                        this.message = $"""$(lead_in_sentence)
 However, no OCaml native-code compiler (ocamlopt or ocamlopt.opt)
 was found during configuration."""
                         return $(this)
@@ -571,15 +571,15 @@ ByteCompilerNotEnabledBuildError. =
 
         new(a_target) =
                 this = $(CompilerNotEnabledBuildError::new $(a_target))
-                lead_in_sencence = $"""You are trying to build OCaml byte-code file "$(a_target)"."""
+                lead_in_sentence = $"""You are trying to build OCaml byte-code file "$(a_target)"."""
                 if $(OCAMLC_EXISTS)
-                        this.message = $"""$(lead_in_sencence)
+                        this.message = $"""$(lead_in_sentence)
 However, the BYTE_ENABLED flag is not set.
 Include the following definition in the relevant OMakefile:
         BYTE_ENABLED = true"""
                         return $(this)
                 else
-                        this.message = $"""$(lead_in_sencence)
+                        this.message = $"""$(lead_in_sentence)
 However, no OCaml byte-code compiler (ocamlc or ocamlc.opt)
 was found during configuration."""
                         return $(this)

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -345,7 +345,7 @@ public.OCAML_LIB_FLAGS =
 # \hypervarx{OCAMLDEP_MODULES_ENABLED}{OCAMLDEP\_MODULES\_ENABLED} is true.
 #
 # \subsubsection{Automatic discovery of generated files during dependency analysis}
-# Having to specify the generated files manualy when \OMake{} could discover them automatically is
+# Having to specify the generated files manually when \OMake{} could discover them automatically is
 # obviously suboptimal.  To address this, we tell \verb+ocamldep+ to \emph{only}
 # find the free module names in a file and then post-process the results internally.
 #
@@ -424,7 +424,7 @@ public.PrintMLIDependencies(filename, cmideps) =
 
 public.PrintMLDependencies(filename, cmideps, cmxdeps) =
     protected.base = $(string-escaped $(removesuffix $(filename)))
-    protected.esc = $' \'
+    protected.esc = $' \' # '
     protected.text =
     if $(cmideps)
         cmideps = $(string-escaped $(cmideps))
@@ -538,43 +538,51 @@ public.OCamlScanner(src_file) =
 # from being called twice: once to generate the .cmi file, and again
 # for the .cmo or .cmx file.
 #
-NativeCompilerNotEnabledBuildError. =
+CompilerNotEnabledBuildError. =
         extends $(UnbuildableException)
+        class CompilerNotEnabledBuildError
+
+        new(a_target) =
+                this.target = $(a_target)
+                this.message = $"""Compiler to build "$(a_target)" is either not enabled or not available."""
+
+NativeCompilerNotEnabledBuildError. =
+        extends $(CompilerNotEnabledBuildError)
         class NativeCompilerNotEnabledBuildError
 
         new(a_target) =
+                this = $(CompilerNotEnabledBuildError::new $(a_target))
+                lead_in_sencence = $"""You are trying to build OCaml native-code file "$(a_target)"."""
                 if $(OCAMLOPT_EXISTS)
-                        export
-                        message = $"""You are trying to build OCaml native-code file "$(a_target)".
+                        this.message = $"""$(lead_in_sencence)
 However, the NATIVE_ENABLED flag is not set.
 Include the following definition in the relevant OMakefile:
         NATIVE_ENABLED = true"""
+                        return $(this)
                 else
-                        export
-                        message = $"""You are trying to build OCaml native-code file "$(a_target)".
-However, no OCaml native-code compiler (ocamlopt or ocamlopt.opt) was found during configuration."""
-                this.target = $(a_target)
-                this.message = $(string $(message))
-                value $(this)
+                        this.message = $"""$(lead_in_sencence)
+However, no OCaml native-code compiler (ocamlopt or ocamlopt.opt)
+was found during configuration."""
+                        return $(this)
 
 ByteCompilerNotEnabledBuildError. =
-        extends $(UnbuildableException)
+        extends $(CompilerNotEnabledBuildError)
         class ByteCompilerNotEnabledBuildError
 
         new(a_target) =
+                this = $(CompilerNotEnabledBuildError::new $(a_target))
+                lead_in_sencence = $"""You are trying to build OCaml byte-code file "$(a_target)"."""
                 if $(OCAMLC_EXISTS)
-                        export
-                        message = $"""You are trying to build OCaml byte-code file "$(a_target)".
+                        this.message = $"""$(lead_in_sencence)
 However, the BYTE_ENABLED flag is not set.
 Include the following definition in the relevant OMakefile:
         BYTE_ENABLED = true"""
+                        return $(this)
                 else
-                        export
-                        message = $"""You are trying to build OCaml byte-code file "$(a_target)".
-However, no OCaml byte-code compiler (ocamlc or ocamlc.opt) was found during configuration."""
-                this.target = $(a_target)
-                this.message = $(string $(message))
-                value $(this)
+                        this.message = $"""$(lead_in_sencence)
+However, no OCaml byte-code compiler (ocamlc or ocamlc.opt)
+was found during configuration."""
+                        return $(this)
 
 public.OCamlC() =
     value $(OCAMLFIND) $(OCAMLC) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS) $(OCAMLFLAGS)\
@@ -617,8 +625,8 @@ public.OCamlOpt() =
 # This is an experimental rule
 %.i.mli: %.ml
     section rule
-	%.i.mli: %.ml %.cmi :scanner: scan-ocaml-%.ml
-		$(OCamlC) -i -c %.ml > $@
+        %.i.mli: %.ml %.cmi :scanner: scan-ocaml-%.ml
+                $(OCamlC) -i -c %.ml > $@
 %.cmo: %.ml
     section rule
         if $(not $(BYTE_ENABLED))

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -538,6 +538,44 @@ public.OCamlScanner(src_file) =
 # from being called twice: once to generate the .cmi file, and again
 # for the .cmo or .cmx file.
 #
+NativeCompilerNotEnabledBuildError. =
+        extends $(UnbuildableException)
+        class NativeCompilerNotEnabledBuildError
+
+        new(a_target) =
+                if $(OCAMLOPT_EXISTS)
+                        export
+                        message = $"""You are trying to build OCaml native-code file "$(a_target)".
+However, the NATIVE_ENABLED flag is not set.
+Include the following definition in the relevant OMakefile:
+        NATIVE_ENABLED = true"""
+                else
+                        export
+                        message = $"""You are trying to build OCaml native-code file "$(a_target)".
+However, no OCaml native-code compiler (ocamlopt or ocamlopt.opt) was found during configuration."""
+                this.target = $(a_target)
+                this.message = $(string $(message))
+                value $(this)
+
+ByteCompilerNotEnabledBuildError. =
+        extends $(UnbuildableException)
+        class ByteCompilerNotEnabledBuildError
+
+        new(a_target) =
+                if $(OCAMLC_EXISTS)
+                        export
+                        message = $"""You are trying to build OCaml byte-code file "$(a_target)".
+However, the BYTE_ENABLED flag is not set.
+Include the following definition in the relevant OMakefile:
+        BYTE_ENABLED = true"""
+                else
+                        export
+                        message = $"""You are trying to build OCaml byte-code file "$(a_target)".
+However, no OCaml byte-code compiler (ocamlc or ocamlc.opt) was found during configuration."""
+                this.target = $(a_target)
+                this.message = $(string $(message))
+                value $(this)
+
 public.OCamlC() =
     value $(OCAMLFIND) $(OCAMLC) $(LAZY_OCAMLFINDFLAGS) $(PREFIXED_OCAMLPACKS) $(OCAMLFLAGS)\
               $(OCAMLCFLAGS) $(OCAMLPPFLAGS) $(PREFIXED_OCAMLINCLUDES)
@@ -549,15 +587,7 @@ public.OCamlOpt() =
 %.cmx: %.ml
     section rule
         if $(not $(NATIVE_ENABLED))
-            err. =
-                extends $(UnbuildableException)
-                message = $(string $"You are trying to build OCaml native code file: "%.cmx$"
-However, the NATIVE_ENABLED flag is not set.
-Include the following definition in your OMakefile
-if you really want to build this file.
-       NATIVE_ENABLED = true")
-                target = $(file %.cmx)
-            raise $(err)
+            raise $(NativeCompilerNotEnabledBuildError.new $(file %.cmx))
         elseif $(target-exists %.mli)
             %.cmx %$(EXT_OBJ): %.ml %.cmi :scanner: scan-ocaml-%.ml
                 $(OCamlOpt) -c $<
@@ -572,15 +602,7 @@ if you really want to build this file.
 %$(EXT_OBJ): %.ml
     section rule
         if $(not $(NATIVE_ENABLED))
-            err. =
-                extends $(UnbuildableException)
-                message = $(string $"You are trying to build OCaml native code file: "%$(EXT_OBJ)$"
-However, the NATIVE_ENABLED flag is not set.
-Include the following definition in your OMakefile
-if you really want to build this file.
-       NATIVE_ENABLED = true")
-                target = $(file %.cmx)
-            raise $(err)
+            raise $(NativeCompilerNotEnabledBuildError.new $(file %$(EXT_OBJ)))
         elseif $(target-exists %.mli)
             %$(EXT_OBJ) %.cmx: %.ml %.cmi :scanner: scan-ocaml-%.ml
                 $(OCamlOpt) -c $<
@@ -595,20 +617,12 @@ if you really want to build this file.
 # This is an experimental rule
 %.i.mli: %.ml
     section rule
-	%.i.mli: %.ml %.cmi  :scanner: scan-ocaml-%.ml
+	%.i.mli: %.ml %.cmi :scanner: scan-ocaml-%.ml
 		$(OCamlC) -i -c %.ml > $@
 %.cmo: %.ml
     section rule
         if $(not $(BYTE_ENABLED))
-            err. =
-                extends $(UnbuildableException)
-                message = $(string $"You are trying to build OCaml native code file: "%.cmo$"
-However, the BYTE_ENABLED flag is not set.
-Include the following definition in your OMakefile
-if you really want to build this file.
-       BYTE_ENABLED = true")
-                target = $(file %.cmx)
-            raise $(err)
+            raise $(ByteCompilerNotEnabledBuildError.new $(file %.cmo))
         elseif $(target-exists %.mli)
             %.cmo: %.ml %.cmi :scanner: scan-ocaml-%.ml
                 $(OCamlC) -c $<
@@ -670,7 +684,7 @@ DeclareMLIOnly(modules) =
            $(mod).cmi $(mod).cmx $(mod).o: $(mod).mli
                $(OCamlC) -c $(mod).mli
                $(OCamlOpt) -c -impl $(mod).mli
-        
+
 
 ########################################################################
 # Parser generators


### PR DESCRIPTION
Rewrite the text of the exceptions raised if an OCaml native compilation or an
OCaml byte compilation is requested (by the rules), but `NATIVE_ENABLED` or
`BYTE_ENABLED` are `false`.  The exception text was well meant, but could lead
to confusion if the respective compiler was not configured (i.e. available) in the
first place.

This should  help with issue #124 

As the handling of automatic variables inside of `section rules` is tricky and
the documentation has been silent about it, add to the OMake documentation,
too.
