### PR TITLE
Pervasives null device

### DIFF
--- a/lib/Pervasives.om
+++ b/lib/Pervasives.om
@@ -56,7 +56,7 @@ const.TAB = $'	'
 const.false = false
 const.true = true
 
-shell-success-null(argv) =
+shell-success(argv) =
     try
         value $(equal $(shell-code $(argv) > $(NULL_DEVICE) >& $(NULL_DEVICE)), 0)
     default

--- a/lib/Pervasives.om
+++ b/lib/Pervasives.om
@@ -56,23 +56,11 @@ const.TAB = $'	'
 const.false = false
 const.true = true
 
-shell-success(argv) =
+shell-success-null(argv) =
     try
-        value $(equal $(shell-code $(argv)), 0)
+        value $(equal $(shell-code $(argv) > $(NULL_DEVICE) >& $(NULL_DEVICE)), 0)
     default
         value $(not true)
-
-shell-success-null(argv) =
-   # XXX: HACK: Is there a portable /dev/null?
-   #            Perhaps we should fix http://bugzilla.metaprl.org/show_bug.cgi?id=619
-   #            and use a string out channel?
-   tmp = $(tmpfile omake.shell-success-null)
-   stdout = $(fopen $(tmp), w)
-   stderr = $(stdout)
-   res = $(shell-success $(argv))
-   close($(stdout))
-   rm(-f $(tmp))
-   return $(res)
 
 last(array) =
    return $(nth $(sub $(length $(array)), 1), $(array))

--- a/lib/Pervasives.om
+++ b/lib/Pervasives.om
@@ -38,6 +38,7 @@ public. =
     declare GLOB_IGNORE
     declare GLOB_OPTIONS
     declare NF
+    declare NULL_DEVICE
     declare OMAKEPATH
     declare PATH
     declare RS
@@ -50,6 +51,7 @@ public. =
 
 const.EMPTY =
 const.EMPTY_ARRAY[] =
+const.NULL_DEVICE = $(if $(equal $(OSTYPE), Win32), NUL, /dev/null)
 const.TAB = $'	'
 const.false = false
 const.true = true

--- a/lib/build/LaTeX.om
+++ b/lib/build/LaTeX.om
@@ -110,7 +110,7 @@ public. =
           export
        export
 
-    if $(and $(LATEX_USABLE), $(shell-success-null latex -help))
+    if $(and $(LATEX_USABLE), $(shell-success latex -help))
         ConfMsgChecking(LaTeX capabilities)
 
         #

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -156,14 +156,14 @@ private.get_bytecomp_c_comp() =
     ConfMsgChecking(whether ocamlc understands the "z" warnings)
     OCAML_ACCEPTS_Z_WARNING =
         if $(OCAMLC_EXISTS)
-            value $(ConfMsgYesNo $(shell-success-null ocamlc$(if $(OCAMLC_OPT_EXISTS), .opt) -w Az))
+            value $(ConfMsgYesNo $(shell-success ocamlc$(if $(OCAMLC_OPT_EXISTS), .opt) -w Az))
         else
             ConfMsgResult($"FAILED - ocamlc not found")
             value false
     ConfMsgChecking(whether ocamlopt can create cmxs plugins)
     CMXS_SUPPORTED =
         if $(OCAMLOPT_EXISTS)
-            ok = $(ConfMsgYesNo $(shell-success-null ocamlopt -shared -o .dummy.cmxs))
+            ok = $(ConfMsgYesNo $(shell-success ocamlopt -shared -o .dummy.cmxs))
             rm(-f .dummy.cmxs)
             value $(ok)
         else
@@ -363,7 +363,7 @@ public.OCAML_LIB_FLAGS =
 #
 .STATIC:
     ConfMsgChecking(if ocamldep understands -modules)
-    OCAMLDEP_MODULES_AVAILABLE = $(ConfMsgYesNo $(shell-success-null ocamldep -modules))
+    OCAMLDEP_MODULES_AVAILABLE = $(ConfMsgYesNo $(shell-success ocamldep -modules))
 
 public.OCAMLDEP_MODULES_ENABLED = $(OCAMLDEP_MODULES_AVAILABLE)
 
@@ -717,7 +717,7 @@ public.MENHIR_ENABLED = false
     MENHIR_RAW_DEPEND = false
     if $(MENHIR_AVAILABLE)
         ConfMsgChecking(if $(MENHIR) supports the --raw-depend option)
-        MENHIR_RAW_DEPEND = $(ConfMsgYesNo $(shell-success-null $(MENHIR) -help | grep $'^ *--raw-depend'))
+        MENHIR_RAW_DEPEND = $(ConfMsgYesNo $(shell-success $(MENHIR) -help | grep $'^ *--raw-depend'))
         export
 
 # Menhir is being requested.  Check that it is installed.

--- a/lib/configure/Configure.om
+++ b/lib/configure/Configure.om
@@ -155,13 +155,13 @@ $(prog)
     
     # Compile it
     fprint($(tmp_c), $(program))
-    protected.result = $(shell-success-null $(command))
+    protected.result = $(shell-success $(command))
 
     export result
     if $(result)
         switch $(extra)
         case Runs
-            result = $(shell-success-null $(file $(tmp)$(EXE)))
+            result = $(shell-success $(file $(tmp)$(EXE)))
         case Output
             result =
                 try

--- a/lib/configure/X.om
+++ b/lib/configure/X.om
@@ -13,7 +13,7 @@ static. =
         CWD = $(dir .)
         cd .conftest.dir
         fprintln(Imakefile, $(EMPTY))
-        if $(and $(shell-success-null xmkmf), $(test -r Makefile))
+        if $(and $(shell-success xmkmf), $(test -r Makefile))
             awk(Makefile)
             case $'^[[:space:]]*INCROOT[[:space:]]*=[[:space:]]*\(.*\)$'
                 FOUND_INCLUDES = true


### PR DESCRIPTION
Introduce the new variable `NULL_DEVICE` in _Pervasives.om_.
Use it to simplify function `shell-success`.

It would be highly welcome if someone on a WIN32 system tests
this branch.  Building OMake from scratch is enough of a test,
because the configuration subsystem uses `shell-success`.
