### PR TITLE
Fix build on Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ force-bootstrap:
 all:
 	$(OCAML) $(OCAMLFLAGS) build.ml -build OCAML="$(OCAML)"
 
-install: all
+install:
 	$(OCAML) $(OCAMLFLAGS) build.ml -install OCAML="$(OCAML)"
 
 clean:

--- a/build.ml
+++ b/build.ml
@@ -317,7 +317,7 @@ let do_action self vars action omake1 omake2 =
           omake1
           env
           vars
-          [ "--dotomake"; ".omake"; "--force-dotomake"; "main" ];
+          [ "--dotomake"; ".omake"; "--force-dotomake"; "-j1"; "main" ];
         (* Windows cannot replace running executables. Create a copy. *)
         if omake1 <> omake2 then
           copy_executable "src/main/omake" "src/main/prelim_omake";
@@ -325,7 +325,7 @@ let do_action self vars action omake1 omake2 =
           omake2
           env
           vars
-          [ "--dotomake"; ".omake"; "--force-dotomake"; "all" ]
+          [ "--dotomake"; ".omake"; "--force-dotomake"; "-j1"; "all" ]
     | `Install ->
         run_omake
           omake2


### PR DESCRIPTION
Closes #139 

For reasons nobody understands MacOS on Apple Silicon rehuses to run `prelim_omake` (which is just a copy of the executable made so far), and just kills the process.

The fix seems to be not to run `make all` again for `make install` - because this runs another bootstrap cycle with another copy, and this causes the problem for Apple's Artificial UnIntelligence that seems the be built into the kernel and detects malware.

Also, this PR disables any parallel build, as this could accidentally overwrite files.