### PR TITLE
fix for "unbound method: sort"

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -498,7 +498,7 @@ public.OCamlScannerPostproc(input) =
     protected.filename =
     protected.modules[] =
     protected.vmounts = $(vmount-map)
-    protected.vmount_source_dirs = $(vmounts)
+    protected.vmount_source_dirs = $(vmounts.keys)
     protected.compare_by_length_descending(a, b) =
         delta_length = $(sub $(b.length), $(a.length))
         value $(if $(eq $(delta_length), $(int 0)), $(compare $a, $b), $(delta_length))


### PR DESCRIPTION
On some platforms `omake` outputs a message like
```
*** omake error:
   File /opt/opam/4.12.0/lib/omake/build/OCaml.om: line 511, characters 42-100
   unbound method: sort
```
and then the dependencies are apparently wrong, leading to unpredictable followup errors (e.g. "the file is not a bytecode file", or just `exception: End_of_file`).

The root cause is a problem in `OCamlScannerPostproc` where it is now tried to take the table of vmounts into account. However, there is a simple programming error in this function, as you cannot sort the vmount map directly, but only the array of the keys of the map. (NB. not all platforms are affected, but only those where the builtin `ocamldep-postproc` is unavailable - we are seeing this on Mac but not on Linux.)