### PR TITLE
fix ocaml build rules

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -614,8 +614,8 @@ public.OCamlOpt() =
                 $(OCamlOpt) -o $@ -c $<
         elseif $(BYTE_ENABLED)
             %.cmx %.cmi %$(EXT_OBJ) %.cmo: %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlC) -o $@ -c $<
-                $(OCamlOpt) -o $(replacesuffixes .cmx, $(EXT_OBJ), $@) -c $<
+                $(OCamlC) -o $(replacesuffixes .cmx, .cmo, $@) -c $<
+                $(OCamlOpt) -o $@ -c $<
         else
             %.cmx %.cmi %$(EXT_OBJ): %.ml :scanner: scan-ocaml-%.ml
                 $(OCamlOpt) -o $@ -c $<
@@ -626,14 +626,14 @@ public.OCamlOpt() =
             raise $(NativeCompilerNotEnabledBuildError.new $(file %$(EXT_OBJ)))
         elseif $(target-exists %.mli)
             %$(EXT_OBJ) %.cmx: %.ml %.cmi :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -o $@ -c $<
+                $(OCamlOpt) -o $(replacesuffixes $(EXT_OBJ), .cmx, $@) -c $<
         elseif $(BYTE_ENABLED)
             %$(EXT_OBJ) %.cmi %.cmx %.cmo: %.ml :scanner: scan-ocaml-%.ml
                 $(OCamlC) -o $(replacesuffixes $(EXT_OBJ), .cmo, $@) -c $<
-                $(OCamlOpt) -o $@ -c $<
+                $(OCamlOpt) -o $(replacesuffixes $(EXT_OBJ), .cmx, $@) -c $<
         else
             %$(EXT_OBJ) %.cmi %.cmx: %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -o $@ -c $<
+                $(OCamlOpt) -o $(replacesuffixes $(EXT_OBJ), .cmx, $@) -c $<
 
 # This is an experimental rule
 %.i.mli: %.ml
@@ -660,14 +660,14 @@ public.OCamlOpt() =
         if $(BYTE_ENABLED)
             if $(NATIVE_ENABLED)
                 %.cmi %.cmo %.cmx %$(EXT_OBJ): %.ml :scanner: scan-ocaml-%.ml
-                    $(OCamlC) -o $@ -c $<
+                    $(OCamlC) -o $(replacesuffixes .cmi, .cmo, $@) -c $<
                     $(OCamlOpt) -o $(replacesuffixes .cmi, .cmx, $@) -c $<
             else
                 %.cmi %.cmo: %.ml :scanner: scan-ocaml-%.ml
-                    $(OCamlC) -o $@ -c $<
+                    $(OCamlC) -o $(replacesuffixes .cmi, .cmo, $@) -c $<
         else
             %.cmi %.cmx %$(EXT_OBJ): %.ml :scanner: scan-ocaml-%.ml
-                $(OCamlOpt) -o $@ -c $<
+                $(OCamlOpt) -o $(replacesuffixes .cmi, .cmx, $@) -c $<
 
 %.cmi: %.mli :scanner: scan-ocaml-%.mli
     $(OCamlC) -o $@ -c $<


### PR DESCRIPTION
Sometimes two of the OCaml build rules match, and actually omake includes a clever trick to avoid problems arising from that: when the second matching rule leads to running exactly the same commands, the second rule is ignored (and only the first matching rule is really run). Besides that this trick avoids that commands are run twice, it also prevents that other commands are influenced by the second rule (e.g. other commands could see partially written files).

Now, a few of the rules got buggy in this respect so that different commands were run, and this caused problems.


fix ocaml build rules so that they aren't run twice and so that
interactions with other commands run in parallel are avoided