### PR TITLE
Split output of option "--help"

### DIFF
--- a/src/ir/omake_options.ml
+++ b/src/ir/omake_options.ml
@@ -2,7 +2,7 @@
  * When to print output.
  *)
 type eval_flag =
-  |  EvalNever
+  | EvalNever
   | EvalLazy
   | EvalEager
 
@@ -18,7 +18,7 @@ type output_flag =
 (*
  * Make the default state explicit (the actual value may depend on the value of other settings).
  *)
-type  setting =
+type setting =
   | Default
   | Set of bool
 
@@ -28,14 +28,14 @@ type  setting =
 type t =
    { job_count            : int;
      remote_servers       : (string * int) list;
-     terminate_on_error   :  setting;
+     terminate_on_error   : setting;
      dry_run              : bool;
      print_command        : eval_flag;
      print_dir            : bool;
      print_file           : bool;
      print_status         : bool;
      print_exit           : bool;
-     mutable print_progress :  setting;
+     mutable print_progress : setting;
      verbose              : bool;
      touch_only           : bool;
      flush_cache          : bool;
@@ -46,7 +46,7 @@ type t =
      verbose_dependencies : bool;
      cd_root              : bool;
      project              : bool;
-     poll                 :  setting;
+     poll                 : setting;
      osh                  : bool;
      poll_on_done         : bool;
      flush_include        : bool;
@@ -83,27 +83,27 @@ let set_job_count_and_servers_opt opts cnt srvs =
  *    3. a machine=count: a remote server that will handle <count> jobs
  *)
 
-let get_job_count (s : string) : int * (string * int) list = 
+let get_job_count (s : string) : int * (string * int) list =
   let set_job (job_count, remote_servers) job =
-    match Lm_string_util.bi_split '=' job with 
-    | (machine,count) -> 
+    match Lm_string_util.bi_split '=' job with
+    | (machine,count) ->
       let count =
         try int_of_string count with
           Failure _ -> 1
       in
       job_count, (machine, count) :: remote_servers
-    | exception Not_found -> 
+    | exception Not_found ->
       try int_of_string job, remote_servers with
         Failure _ ->
         job_count, (job, 1) :: remote_servers
   in
-  let job_count, remote_servers = 
+  let job_count, remote_servers =
     List.fold_left (fun acc x -> set_job acc x)  (1, []) (Lm_string_util.split ":" s) in
-  job_count , List.rev remote_servers 
+  job_count , List.rev remote_servers
 
 let set_job_count (options : t) (s: string) : t   =
   let job_count, remote_servers = get_job_count s in
-  set_job_count_and_servers_opt options (max  1 job_count) remote_servers 
+  set_job_count_and_servers_opt options (max  1 job_count) remote_servers
 
 
 
@@ -390,45 +390,46 @@ let default_options =
  * put in the option list in Omake_main, not here.
  *)
 let options_spec =
-   ["-j", Lm_arg.StringFold set_job_count, (**)
-       "Specify parallel jobs and remote servers";
-    "-k", Lm_arg.ClearFold set_terminate_on_error_opt, (**)
-       "Do not stop when an error occurs; implied by -p and -P";
-    "-p", Lm_arg.SetFold set_poll_opt, (**)
-       "Poll filesystem for changes (until build succeeds); implies -k";
-    "-P", Lm_arg.SetFold set_poll_on_done_opt, (**)
-       "Poll filesystem for changes (keep polling \"forever\"); implies -k and -p";
-    "-n", Lm_arg.SetFold set_dry_run_opt, (**)
-       "Print commands, but do not execute them";
-    "--project", Lm_arg.SetFold set_project_opt, (**)
-       "Ignore the current directory and build the project";
-    "-t", Lm_arg.SetFold set_touch_only_opt, (**)
-       "Update database to force files to be up-to-date";
-    "--depend", Lm_arg.SetFold set_flush_dependencies_opt, (**)
-       "Do not trust cached dependecy information";
-    "-U", Lm_arg.SetFold set_flush_cache_opt, (**)
-       "Do not trust the dependency cache or cached OMakefiles";
-    "--flush-includes", Lm_arg.SetFold set_flush_include_opt, (**)
-       "Do not trust cached .omc files";
-    "--configure", Lm_arg.SetFold set_flush_static_opt, (**)
-       "Recompute static. sections";
-    "-R", Lm_arg.SetFold set_cd_root_opt, (**)
-       "Command-line targets are relative to the project root; builds all .DEFAULT targets if no targets given";
-    "--print-dependencies", Lm_arg.SetFold set_print_dependencies_opt, (**)
-       "Build and print dependencies";
-    "--show-dependencies", Lm_arg.StringFold add_show_dependency_opt, (**)
-       "Show dependencies if the file is built";
-    "--all-dependencies", Lm_arg.SetFold set_all_dependencies_opt, (**)
-       "For --print-dependencies and --show-dependencies, print dependencies recursively";
-    "--verbose-dependencies", Lm_arg.SetFold set_verbose_dependencies_opt, (**)
-       "For --print-dependencies and --show-dependencies, print all dependencies too";
-    "--absname", Lm_arg.SetFold set_absname_opt, (**)
-       "Filenames are always displayed as absolute paths";
-    "-Wdeclare", Lm_arg.SetFold set_warn_declare_opt, (**)
-       "Warn about undeclared variables";
-    "-warn-error", Lm_arg.SetFold set_warn_error_opt, (**)
-       "Treat warnings as errors"
-   ]
+  ["-j", Lm_arg.StringFold set_job_count, (**)
+   "N  specify maximum number N of parallel jobs and remote servers";
+   "-k", Lm_arg.ClearFold set_terminate_on_error_opt, (**)
+   " do not stop when an error occurs; implied by -p and -P";
+   "-p", Lm_arg.SetFold set_poll_opt, (**)
+   " poll filesystem for changes (until build succeeds); implies -k";
+   "-P", Lm_arg.SetFold set_poll_on_done_opt, (**)
+   " poll filesystem for changes (keep polling \"forever\"); implies -k and -p";
+   "-n", Lm_arg.SetFold set_dry_run_opt, (**)
+   " print commands, but do not execute them";
+   "--project", Lm_arg.SetFold set_project_opt, (**)
+   " ignore the current directory and build the project";
+   "-t", Lm_arg.SetFold set_touch_only_opt, (**)
+   " update database to force files to be up-to-date";
+   "--depend", Lm_arg.SetFold set_flush_dependencies_opt, (**)
+   " do not trust cached dependency information";
+   "-U", Lm_arg.SetFold set_flush_cache_opt, (**)
+   " do not trust the dependency cache or cached OMakefiles";
+   "--flush-includes", Lm_arg.SetFold set_flush_include_opt, (**)
+   " do not trust cached .omc files";
+   "--configure", Lm_arg.SetFold set_flush_static_opt, (**)
+   " recompute static. sections";
+   "-R", Lm_arg.SetFold set_cd_root_opt, (**)
+   " command-line targets are relative to the project root; \
+    builds all .DEFAULT targets if no targets given";
+   "--print-dependencies", Lm_arg.SetFold set_print_dependencies_opt, (**)
+   " build and print dependencies";
+   "--show-dependencies", Lm_arg.StringFold add_show_dependency_opt, (**)
+   "TARGET  show dependencies if TARGET is built";
+   "--all-dependencies", Lm_arg.SetFold set_all_dependencies_opt, (**)
+   " for --print-dependencies and --show-dependencies, print dependencies recursively";
+   "--verbose-dependencies", Lm_arg.SetFold set_verbose_dependencies_opt, (**)
+   " for --print-dependencies and --show-dependencies, print all dependencies too";
+   "--absname", Lm_arg.SetFold set_absname_opt, (**)
+   " filenames are always displayed as absolute paths";
+   "-Wdeclare", Lm_arg.SetFold set_warn_declare_opt, (**)
+   " warn about undeclared variables";
+   "-warn-error", Lm_arg.SetFold set_warn_error_opt, (**)
+   " treat warnings as errors"
+  ]
 
 let progress_usage =
    match Sys.os_type with
@@ -442,7 +443,7 @@ let progress_usage =
  *)
 let output_spec =
   [
-    "--verbose", 
+    "--verbose",
     Lm_arg.UnitFold
       (fun options ->
          { options with
@@ -452,13 +453,14 @@ let output_spec =
            print_exit = true;
            print_file = true
          }),
-    "Verbose output (equivalent to \"--no-S --print-status --print-exit VERBOSE=true\")";
-   
-    "--print-exit", Lm_arg.SetFold set_print_exit_opt, "Print the exit codes of commands";
+    " verbose output (equivalent to \"--no-S --print-status --print-exit VERBOSE=true\")";
+
+    "--print-exit", Lm_arg.SetFold set_print_exit_opt,
+    " print the exit codes of commands";
 
     "-S", Lm_arg.SetFold
-      (fun options b -> { options with print_command = if b then EvalLazy else EvalEager }), 
-    "Print command only if the command prints output (default)";
+      (fun options b -> { options with print_command = if b then EvalLazy else EvalEager }),
+    " print command only if the command prints output (default)";
 
     "-s", Lm_arg.ClearFold (fun options b ->
         { options with print_status  = b;
@@ -466,30 +468,31 @@ let output_spec =
                        print_file    = b;
                        print_exit    = b;
                        print_command = if b then EvalEager else EvalNever }),
-    "Never print commands before they are executed";
+    " never print commands before they are executed";
 
     "--progress", Lm_arg.SetFold set_print_progress_opt,
-    ("Print a progress indicator " ^ progress_usage);
+    (" print a progress indicator " ^ progress_usage);
 
     "--print-status", Lm_arg.SetFold set_print_status_opt,
-    "Print status lines (default)";
+    " print status lines (default)";
 
     "-w", Lm_arg.SetFold set_print_dir_opt,
-    "Print the directory in \"make format\" as commands are executed";
+    " print the directory in \"make format\" as commands are executed";
 
-    "--output-normal", Lm_arg.SetFold (set_output_opt OutputNormal), 
-    "Relay the output of the rule commands to the OMake output right away. This is the default when no --output-postpone and no --output-only-errors flags are given.";
+    "--output-normal", Lm_arg.SetFold (set_output_opt OutputNormal),
+    " relay the output of the rule commands to the OMake output right away; \
+     this is the default when no --output-postpone and no --output-only-errors flags are given.";
 
     "--output-postpone", Lm_arg.SetFold (fun opt flag ->
-        set_output_opt OutputPostponeSuccess (set_output_opt OutputPostponeError opt flag) flag), 
-    "Postpone printing command output until a rule terminates.";
+        set_output_opt OutputPostponeSuccess (set_output_opt OutputPostponeError opt flag) flag),
+    " postpone printing command output until a rule terminates";
 
-    "--output-only-errors", Lm_arg.SetFold (set_output_opt OutputPostponeError), 
-    "Same as --output-postpone, but postponed output will only be printed for commands that fail.";
+    "--output-only-errors", Lm_arg.SetFold (set_output_opt OutputPostponeError),
+    " same as --output-postpone, but postponed output will only be printed for commands that fail";
 
-    "--output-at-end", Lm_arg.SetFold (set_output_opt OutputRepeatErrors), 
-    "The output of the failed commands will be printed after OMake have stopped. Off by default, unless -k is enabled (directly or via -p/-P).";
+    "--output-at-end", Lm_arg.SetFold (set_output_opt OutputRepeatErrors),
+    " the output of the failed commands will be printed after OMake has stopped; \
+     off by default, unless -k is enabled (directly or via -p/-P)";
     "-o", Lm_arg.StringFold set_output_opts, (**)
-    "Short output options [01jwWpPxXsS] (see the manual)";
+    "SHORT-OPTION  short output options [012wWpPxXsS] (see the manual page or manual)";
   ]
-

--- a/src/libmojave/lm_arg.ml
+++ b/src/libmojave/lm_arg.ml
@@ -159,7 +159,7 @@ let char_table_lookup table ch =
   with
     Not_found ->
     (* If the character is '_', try looking it up as '-'. This is a
-       hack to accomodate both '_' and '-' in option names (proper
+       hack to accommodate both '_' and '-' in option names (proper
        GCC style uses hyphen, but our old options used underscores). *)
     if ch = '_' then
       try
@@ -413,7 +413,7 @@ let usage_arg = function
 
 (* usage
    Display the usage message and help text for the options.  *)
-let usage opt_width spec =
+let print_usage opt_width spec =
    List.iter (fun (opt, spec, doc) ->
          (* Descriptive text for the option argument *)
          let opt = opt ^ (usage_arg spec) in
@@ -444,7 +444,7 @@ let usage (mode, spec) usage_msg =
    Lm_printf.printf "@[<v 0>%s." usage_msg;
    List.iter (fun (section, spec) ->
       Lm_printf.printf "@ @ @[<v 3>%s:" section;
-      usage opt_width spec;
+      print_usage opt_width spec;
       Lm_printf.printf "@]") spec;
    (match mode with
        StrictOptions ->
@@ -513,9 +513,6 @@ let rec get_next_option mode argv argv_length current =
    -help or --help is intercepted on the argument stream, then the
    usage message is displayed.  *)
 let fold_argv argv (mode_info, spec_info) arg default usage_msg =
-  (* Always add the --help flag *)
-  let spec_info = ("Help flags", ["--help", Usage, "Display a help message"]) :: spec_info in
-
   (* Set the current mode *)
   let mode =
     match mode_info with

--- a/src/magic/omake_gen_magic.ml
+++ b/src/magic/omake_gen_magic.ml
@@ -56,9 +56,9 @@ let shorten_version s =
 
 
 (* Figure out if the line is a magic directive. *)
-(* 
+(*
 {[
-magic_line_type "(\* %%MAGICEND%% *\)";; 
+magic_line_type "(\* %%MAGICEND%% *\)";;
 `END
 magic_line_type "(* %%MAGICBEGIN%% *)";;
 `Begin
@@ -107,16 +107,16 @@ let copy_magic_file outx inp : unit =
           output_char outx '\n'
         end;
       copy inx magic_flag in
-  match open_in inp with 
+  match open_in inp with
   | exception  Sys_error _ ->
     Printf.eprintf "Can't open %s\n" inp;
     flush stderr;
     exit 1
-  | inx -> 
+  | inx ->
     try copy inx false with End_of_file -> close_in inx
 
-    
-let omake_magic (buf : out_channel) 
+
+let omake_magic (buf : out_channel)
     version_txt
     default_save_interval
     libdir
@@ -140,7 +140,7 @@ let omake_magic (buf : out_channel)
       in
       String.escaped (code ^ digest) in
   let version = read_version version_txt in
-  let tm =  Unix.(localtime (time ())) in 
+  let tm =  Unix.(localtime (time ())) in
   Printf.fprintf buf {|
 let default_save_interval = %F
 let input_magic inx = let s = Bytes.make %d ' ' in really_input inx s 0 %d; Bytes.to_string s
@@ -150,7 +150,7 @@ let ir_magic = "%s"
 let obj_magic = "%s"
 let lib_dir = "%s"
 let version = "%s"
-let version_message = "OMake %s:\\n\\tbuild [%s %s %d %02d:%02d:%02d %d]\\n\\ton %s"
+let version_message = "OMake %s:\n    build [%s %s %d %02d:%02d:%02d %d]\n    on %s"
 |}
        default_save_interval
        digest_len
@@ -214,7 +214,7 @@ let output_file = ref None
 let cache_files = ref []
 let omc_files   = ref []
 let omo_files   = ref []
-let default_save_interval = ref 15.0 
+let default_save_interval = ref 15.0
 let vars        = ref []
 
 
@@ -232,22 +232,22 @@ let anon s =
 
 let spec : (string * Arg.spec * string) list =
    ["--magic", Set make_magic, "generate the omake_magic.ml file";
-    
+
     "--cache-files", Unit (fun () -> mode := CacheFiles), "specify the magic files for the cache magic number";
     "--omc-files", Unit (fun () -> mode := OmcFiles), "specify the files to scan for the IR magic number";
     "--omo-files", Unit (fun () -> mode := OmoFiles), "specify the files to scan for the object magic number";
     "--version", String (fun s -> version_txt := s), "specify the version.txt file";
-  
+
     "-o",String (fun s -> output_file := Some s), "set the output file";
     "--lib", String (fun s -> libdir := Some s), "specify the location of the library directory";
     "--root", String (fun s -> make_root := Some s),  "generate the OMakeroot file";
     "--default_save_interval",
     Float (fun f -> default_save_interval := f), "specify the default .omakedb save interval";
-    "--var", String (fun s -> 
+    "--var", String (fun s ->
                      let (name,value) =
                        try
                          let p = String.index s '=' in
-                         (String.sub s 0 p, 
+                         (String.sub s 0 p,
                           String.sub s (p+1) (String.length s - p - 1)
                          )
                        with Not_found -> failwith ("bad --var: " ^ s) in
@@ -270,8 +270,8 @@ let main () =
     | None ->
       raise (Invalid_argument "use the -o option to specify an output file")
   in
-  let libdir = 
-    match !libdir with 
+  let libdir =
+    match !libdir with
     | Some s -> Filename.concat s "omake"
     | None -> Filename.concat (Filename.dirname (Unix.getcwd ())) "lib"
   in
@@ -288,4 +288,3 @@ let main () =
 
 let _ =
    Printexc.catch main ()
-

--- a/src/main/omake_main.ml
+++ b/src/main/omake_main.ml
@@ -14,120 +14,268 @@ let install_subdirs = ref false
 let install_force = ref false
 let extended_rusage = ref false
 
+
+let is_white = function
+  | '\t' | '\r' | '\n' | ' ' -> true
+  | _ -> false
+
+let wrap_string ~first_line_prefix ~next_line_prefix ~line_length ~initial_offset a_string =
+  let string_length = String.length a_string in
+    let index = ref initial_offset
+    and lookahead_index = ref 0
+    and column = ref 0
+    and output = Buffer.create (16 + string_length + string_length / line_length) in
+      Buffer.add_string output first_line_prefix;
+      column := String.length first_line_prefix;
+      while !index < string_length do
+        while !index < string_length && is_white a_string.[!index] do incr index done;
+        lookahead_index := !index + 1;
+        while !lookahead_index < string_length && not (is_white a_string.[!lookahead_index]) do
+          incr lookahead_index
+        done;
+        let word_length = !lookahead_index - !index in
+          if !column = 0 then
+            ()
+          else if !column + 1 + word_length > line_length then
+            begin
+              Buffer.add_char output '\n';
+              Buffer.add_string output next_line_prefix;
+              column := String.length next_line_prefix
+            end
+          else
+            begin
+              Buffer.add_char output ' ';
+              incr column
+            end;
+          Buffer.add_substring output a_string !index word_length;
+          column := !column + word_length;
+          index := !lookahead_index + 1
+      done;
+      Buffer.contents output
+
+let negateable_option_marker = "<N>"
+
+let print_help_intro () =
+  print_endline ("Usage: " ^ Sys.argv.(0) ^ " [OPTIONS...] [TARGET...]");
+  print_endline "Run OMake in the current directory to build TARGET.";
+  print_endline "If called as osh start the OMake shell Osh.";
+  print_newline ();
+  print_endline ("A `" ^ negateable_option_marker ^ "' symbol indicates options that can be negated by");
+  print_endline "prefixing them with `--no' as, e.g., `--no-S' or";
+  print_endline "`--no--print-status'.  Note the conserved inner double";
+  print_endline "dash of the latter, though.";
+  print_newline ();
+  print_string "Options:"
+and print_help_outro () =
+  print_newline ();
+  print_endline "Report bugs to <https://github.com/ocaml-omake/omake/issues>"
+
+let print_help_on_option (option_name, option_poly_spec, option_description) =
+  let is_negateable = function
+    | Lm_arg.Set _ | Clear _ | SetFold _ | ClearFold _ -> true
+    | _ -> false in
+    let initial_indent_length = 2
+    and name_column_width = 28
+    and total_width = 79
+    and name_spec = Buffer.create 32
+    and description_offset = if is_white option_description.[0] then 0
+                             else
+                               let index = ref 1 in
+                                 while !index < String.length option_description &&
+                                         not (is_white option_description.[!index]) do
+                                   incr index
+                                 done;
+                                 !index
+    in
+      Buffer.add_string name_spec (String.make initial_indent_length ' ');
+      Buffer.add_string name_spec option_name;
+      if description_offset > 0 then
+        begin
+          Buffer.add_char name_spec ' ';
+          Buffer.add_substring name_spec option_description 0 description_offset
+        end;
+      let pad_length = name_column_width + initial_indent_length - Buffer.length name_spec in
+        if pad_length < 1 then
+          begin
+            print_endline (Buffer.contents name_spec);
+            Buffer.clear name_spec;
+            Buffer.add_string name_spec (String.make (initial_indent_length + name_column_width) ' ');
+          end
+        else
+          Buffer.add_string name_spec (String.make pad_length ' ');
+
+        print_endline
+          (wrap_string
+             ~first_line_prefix:(Buffer.contents name_spec)
+             ~next_line_prefix:(String.make (initial_indent_length + name_column_width + 1) ' ')
+             ~line_length:total_width
+             ~initial_offset:description_offset
+             option_description ^
+             (if is_negateable option_poly_spec then " " ^ negateable_option_marker else ""))
+
+let print_help_on_option_group group_name spec =
+  print_newline ();
+  print_char ' ';
+  print_string group_name;
+  print_endline ":";
+  List.iter print_help_on_option spec
+
+let show_version () =
+  print_endline Omake_magic.version_message;
+  print_string "Default library directory: ";
+  print_endline Omake_magic.lib_dir;
+  if Omake_state.lib_dir_reason <> "" then
+    begin
+      print_string "Using library directory: ";
+      print_string Omake_state.lib_dir;
+      print_string " as specified by the ";
+      print_endline Omake_state.lib_dir_reason
+    end;
+  print_newline ();
+  print_endline "License GPLv2: GNU GPL version 2 <http://gnu.org/licenses/gpl.html>";
+  print_endline "This is free software: you are free to change and redistribute it.";
+  print_endline "There is NO WARRANTY, to the extent permitted by law.";
+  exit 0
+
 (*
  * Arguments.
  *)
 let header = "OMake generic system builder, version " ^ Omake_magic.version
 
+let rec debug_spec =
+  ["-print-ast", Lm_arg.Set Omake_eval.print_ast, (**)
+   " print the AST after parsing";
+   "-print-ir", Lm_arg.Set Omake_eval.print_ir, (**)
+   " print the IR";
+   "-print-loc", Lm_arg.Set Omake_ast_print.print_location, (**)
+   " also print locations";
+   "-print-rules", Lm_arg.Set Omake_eval.print_rules, (**)
+   " print the rules after evaluation";
+   "-print-files", Lm_arg.Set Omake_eval.print_files, (**)
+   " print the files as they are read";
+   "-debug-deps", Lm_arg.Set Omake_build.debug_deps, (**)
+   " display dependency information as scanned";
+   "-debug-ast-lex", Lm_arg.Set Omake_ast_lex.debug_lex, (**)
+   " print tokens as they are scanned";
+   "-debug-cache", Lm_arg.Set Omake_cache.debug_cache, (**)
+   " display cache debugging information";
+   "-debug-exec", Lm_arg.Set Omake_exec_util.debug_exec, (**)
+   " display execution debugging information";
+   "-debug-rule", Lm_arg.Set Omake_build.debug_rule, (**)
+   " display debugging information about rule execution";
+   "-debug-build", Lm_arg.Set Omake_build.debug_build, (**)
+   " display debugging information during the build";
+   "-debug-scanner", Lm_arg.Set Omake_env.debug_scanner, (**)
+   " display debugging information for scanner selection";
+   "-debug-implicit", Lm_arg.Set Omake_env.debug_implicit, (**)
+   " display debugging information for implicit rule selection";
+   "-debug-pos", Lm_arg.Set Lm_position.debug_pos, (**)
+   " print source position information on error";
+   "-trace-pos", Lm_arg.Set Lm_position.trace_pos, (**)
+   " trace the program execution";
+   "-debug-remote", Lm_arg.Set Omake_exec_remote.debug_remote, (**)
+   " debug remote execution";
+   "-debug-active-rules", Lm_arg.Set Omake_rule.debug_active_rules, (**)
+   " debug active rules";
+   "-debug-shell", Lm_arg.Set Omake_shell_type.debug_shell, (**)
+   " debug shell operations";
+   "-debug-eval", Lm_arg.Set Omake_eval.debug_eval, (**)
+   " debug the evaluator";
+   "-debug-lex", Lm_arg.Set Lm_lexer.debug_lex, (**)
+   " debug the lexer";
+   "-debug-lexgen", Lm_arg.Set Lm_lexer.debug_lexgen, (**)
+   " debug the lexer generator";
+   "-debug-parse", Lm_arg.Set Lm_parser.debug_parse, (**)
+   " debug the parser";
+   "-debug-parsegen", Lm_arg.Set Lm_parser.debug_parsegen, (**)
+   " debug the parser generator";
+   "-debug-parsing", Lm_arg.Set Omake_builtin_io_fun.debug_parsing, (**)
+   " debug OMake parsing operations";
+   "-debug-notify", Lm_arg.Set Lm_notify.debug_notify, (**)
+   " debug the FAM (-p filesystem watch) operations";
+   "-debug-db", Lm_arg.Set Omake_env.debug_db, (**)
+   " debug the file database";
+   "-debug-hash", Lm_arg.Set debug_hash, (**)
+   " show Lm_hash statistics";
+   "-debug-thread", Lm_arg.Set Lm_thread_pool.debug_thread, (**)
+   " show thread operations";
+   "-allow-exceptions", Lm_arg.SetFold Omake_options.set_allow_exceptions_opt, (**)
+   " do not catch top-level exceptions (for use with OCAMLRUNPARAM=b)";
+   "-extended-rusage", Lm_arg.Set extended_rusage, (**)
+   " print more about resource usage";
+   "-instrument", Lm_arg.Set Lm_instrument.enabled, (**)
+   " do instrument functions"]
+and cache_spec =
+  ["--save-interval", Lm_arg.Float (fun f -> Omake_build.save_interval := f), (**)
+   (Lm_printf.sprintf
+      "DURATION  save the build DB (\".omakedb\") every DURATION seconds (0 disables, default: %.3f)" (**)
+      Omake_magic.default_save_interval);
+   "--force-dotomake", Lm_arg.Set Omake_state.always_use_dotomake, (**)
+   " always use \"$HOME/.omake\" for .omc cache files";
+   "--dotomake", Lm_arg.String Omake_state.set_omake_dir, (**)
+   " use the specified directory in place of \"$HOME/.omake\""]
+and helper_spec =
+  ["--install", Lm_arg.Set install_flag, (**)
+   " install an OMake project into the current directory";
+   "--install-all", Lm_arg.SetFold (fun opts b -> install_flag := b; install_subdirs := b; opts), (**)
+   " install an OMake project into the current directory and all subdirectories";
+   "--install-force", Lm_arg.SetFold (fun opts b -> install_flag := b; install_force := b; opts), (**)
+   " force overwriting of files during installation; implies --install";
+   "-server", Lm_arg.String (fun s -> server_flag := Some s), "SERVER-NAME  run as remote server";
+   "--help", (**)
+   Lm_arg.Unit (fun () ->
+       print_help_intro ();
+       print_help_on_option_group "Build Control" Omake_options.options_spec;
+       print_help_on_option_group "Output" Omake_options.output_spec;
+       print_help_on_option_group "Cache Management" cache_spec;
+       print_help_on_option_group "Shell Related" shell_spec;
+       print_help_on_option_group "Miscellaneous" helper_spec;
+       print_help_outro ();
+       exit 0),
+   " display help message and exit";
+   "--help-debug", (**)
+   Lm_arg.Unit (fun () ->
+       print_help_intro ();
+       print_help_on_option_group "Debug Options" debug_spec;
+       print_help_outro ();
+       exit 0),
+   " display help message just for the debugging-related options and exit";
+   "--help-all", (**)
+   Lm_arg.Unit (fun () ->
+       print_help_intro ();
+       print_help_on_option_group "Build Control" Omake_options.options_spec;
+       print_help_on_option_group "Output" Omake_options.output_spec;
+       print_help_on_option_group "Cache Management" cache_spec;
+       print_help_on_option_group "Shell Related" shell_spec;
+       print_help_on_option_group "Debugging" debug_spec;
+       print_help_on_option_group "Miscellaneous" helper_spec;
+       print_help_outro ();
+       exit 0),
+   " display help message for all options and exit";
+   "--version", Lm_arg.Unit show_version, (**)
+   " print the version string and exit"]
+and shell_spec =
+  ["--shell", Lm_arg.Set shell_flag, (**)
+   " run the OMake shell: osh(1)";
+   "-i", Lm_arg.SetFold (fun opts b -> Lm_readline.set_interactive b; opts), (**)
+   " treat the session as interactive";
+   "-c", Lm_arg.String (fun s -> command_string := Some s), (**)
+   "COMMAND  evaluate the COMMANDs from the string"]
+
 let spec =
   Lm_arg.StrictOptions, (**)
-  Omake_options.(
   ["Make flags", (**)
-   options_spec;
+   Omake_options.options_spec;
    "Output flags", (**)
-   output_spec;
+   Omake_options.output_spec;
    "Cache management", (**)
-   ["--save-interval", Lm_arg.Float (fun f -> Omake_build.save_interval := f), (**)
-    (Lm_printf.sprintf "Save the build DB (\".omakedb\") every x seconds (0 disables, default: %F)" (**)
-       Omake_magic.default_save_interval);
-    "--force-dotomake", Lm_arg.Set Omake_state.always_use_dotomake, (**)
-    "Always use $HOME/.omake for .omc cache files";
-    "--dotomake", Lm_arg.String (fun s -> Omake_state.set_omake_dir s), (**)
-    "Use the specified directory in place of $HOME/.omake"];
+   cache_spec;
    "Helper flags", (**)
-   ["--install", Lm_arg.Set install_flag, (**)
-    "Install an OMake project into the current directory";
-    "--install-all", Lm_arg.SetFold (fun opts b ->
-      install_flag := b;
-      install_subdirs := b;
-      opts), (**)
-    "Install an OMake project into the current directory and all subdirectories";
-    "--install-force", Lm_arg.SetFold (fun opts b ->
-      install_flag := b;
-      install_force := b;
-      opts), (**)
-    "Force overwriting of files during installation; implies --install";
-    "--version", Lm_arg.Unit (fun () ->
-      Lm_printf.printf "%s\n\nDefault library directory : %s@." Omake_magic.version_message Omake_magic.lib_dir;
-      if Omake_state.lib_dir_reason <> "" then
-        Lm_printf.printf "Using library directory   : %s\n\t(as specified by the %s)@." (**)
-          Omake_state.lib_dir Omake_state.lib_dir_reason;
-      exit 0), (**)
-    "Print the version string and exit"];
+   helper_spec;
    "Shell flags", (**)
-   ["--shell", Lm_arg.Set shell_flag, (**)
-    "Run the OMake shell: osh";
-    "-i", Lm_arg.SetFold (fun opts b -> Lm_readline.set_interactive b; opts), (**)
-    "Treat the session as interactive";
-    "-c", Lm_arg.String (fun s -> command_string := Some s), (**)
-    "Evaluate the commands from the string"];
+   shell_spec;
    "Debugging flags", (**)
-   ["-print-ast",      Lm_arg.Set Omake_eval.print_ast, (**)
-    "Print the AST after parsing";
-    "-print-ir",       Lm_arg.Set Omake_eval.print_ir, (**)
-    "Print the IR";
-    "-print-loc",       Lm_arg.Set Omake_ast_print.print_location, (**)
-    "Also print locations";
-    "-print-rules",    Lm_arg.Set Omake_eval.print_rules, (**)
-    "Print the rules after evaluation";
-    "-print-files",    Lm_arg.Set Omake_eval.print_files, (**)
-    "Print the files as they are read";
-    "-debug-deps",     Lm_arg.Set Omake_build.debug_deps, (**)
-    "Display dependency information as scanned";
-    "-debug-ast-lex",  Lm_arg.Set Omake_ast_lex.debug_lex, (**)
-    "Print tokens as they are scanned";
-    "-debug-cache",    Lm_arg.Set Omake_cache.debug_cache, (**)
-    "Display cache debugging information";
-    "-debug-exec",     Lm_arg.Set Omake_exec_util.debug_exec, (**)
-    "Display execution debugging information";
-    "-debug-rule",     Lm_arg.Set Omake_build.debug_rule, (**)
-    "Display debugging information about rule execution";
-    "-debug-build",    Lm_arg.Set Omake_build.debug_build, (**)
-    "Display debugging information during the build";
-    "-debug-scanner",  Lm_arg.Set Omake_env.debug_scanner, (**)
-    "Display debugging information for scanner selection";
-    "-debug-implicit", Lm_arg.Set Omake_env.debug_implicit, (**)
-    "Display debugging information for implicit rule selection";
-    "-debug-pos", Lm_arg.Set Lm_position.debug_pos, (**)
-    "Print source position information on error";
-    "-trace-pos", Lm_arg.Set Lm_position.trace_pos, (**)
-    "Trace the program execution";
-    "-debug-remote", Lm_arg.Set Omake_exec_remote.debug_remote, (**)
-    "Debug remote execution";
-    "-debug-active-rules", Lm_arg.Set Omake_rule.debug_active_rules, (**)
-    "Debug active rules";
-    "-debug-shell", Lm_arg.Set Omake_shell_type.debug_shell, (**)
-    "Debug shell operations";
-    "-debug-eval", Lm_arg.Set Omake_eval.debug_eval, (**)
-    "Debug the evaluator";
-    "-debug-lex", Lm_arg.Set Lm_lexer.debug_lex, (**)
-    "Debug the lexer";
-    "-debug-lexgen", Lm_arg.Set Lm_lexer.debug_lexgen, (**)
-    "Debug the lexer generator";
-    "-debug-parse", Lm_arg.Set Lm_parser.debug_parse, (**)
-    "Debug the parser";
-    "-debug-parsegen", Lm_arg.Set Lm_parser.debug_parsegen, (**)
-    "Debug the parser generator";
-    "-debug-parsing", Lm_arg.Set Omake_builtin_io_fun.debug_parsing, (**)
-    "Debug OMake parsing operations";
-    "-debug-notify", Lm_arg.Set Lm_notify.debug_notify, (**)
-    "Debug the FAM (-p filesystem watch) operations";
-    "-debug-db", Lm_arg.Set Omake_env.debug_db, (**)
-    "Debug the file database";
-    "-debug-hash", Lm_arg.Set debug_hash, (**)
-    "Show Lm_hash statistics";
-    "-debug-thread", Lm_arg.Set Lm_thread_pool.debug_thread, (**)
-    "Show thread operations";
-    "-allow-exceptions", Lm_arg.SetFold set_allow_exceptions_opt, (**)
-    "Do not catch top-level exceptions (for use with OCAMLRUNPARAM=b)";
-    "-extended-rusage", Lm_arg.Set extended_rusage, (**)
-    "Print more about resource usage";
-    "-instrument", Lm_arg.Set Lm_instrument.enabled, (**)
-    "Do instrument functions";
-   ];
-   "Internal flags", (**)
-   ["-server", Lm_arg.String (fun s -> server_flag := Some s), (**)
-    "Run as a remote server";]])
+   debug_spec]
 
 
 
@@ -135,12 +283,12 @@ let spec =
  * Main program.
  *)
 let main (options : Omake_options.t) =
-  begin 
+  begin
     Sys.catch_break true ;
     (if Sys.os_type <> "Win32" then
        Sys.set_signal Sys.sigpipe Signal_ignore );
     let path = Omake_main_util.chroot () in
-    Omake_build.build options 
+    Omake_build.build options
       (if  options.cd_root then
          "."
        else
@@ -148,13 +296,13 @@ let main (options : Omake_options.t) =
       (match !targets with
        | [] -> [".DEFAULT"]
        | l -> List.rev l);
-    if !debug_hash then 
+    if !debug_hash then
       Omake_main_util.print_hash_stats ();
     if !extended_rusage then (
       let r = Unix.times() in
       let open Unix in
       Lm_printf.eprintf "Resources used by main process:     \
-                         user %.2fseconds, system %.2fseconds\n" 
+                         user %.2fseconds, system %.2fseconds\n"
                         r.tms_utime r.tms_stime;
       Lm_printf.eprintf "Resources used incl. sub processes: \
                          user %.2fseconds, system %.2fseconds\n"
@@ -168,14 +316,14 @@ let _ =
   let add_unknown options s =
     begin
       ( match Lm_string_util.bi_split  '=' s  with
-        | (v,x) -> 
+        | (v,x) ->
           Omake_build_util.add_command_def v x
         | exception Not_found -> targets := s :: !targets);
       options, !shell_flag
     end
   in
   let exe = Lm_filename_util.root (Filename.basename (Sys.argv.(0))) in
-  let () = 
+  let () =
     if exe = "osh" then
       shell_flag := true in
 
@@ -193,14 +341,13 @@ let _ =
     try Lm_arg.fold spec options add_unknown header with
     | Lm_arg.UsageError -> exit 0
     | Lm_arg.BogusArg s ->
-      Lm_arg.usage spec header;
       Lm_printf.eprintf "@\n@[<hv 3>*** omake fatal error:@ %s@]@." s;
       exit 3  in
   Lm_thread_core.debug_mutex := !Lm_thread_pool.debug_thread;
   Lm_thread.debug_lock := !Lm_thread_pool.debug_thread;
   (* Run it *)
   match !server_flag with
-  | Some cwd -> Omake_main_util.main_remote cwd options !targets 
+  | Some cwd -> Omake_main_util.main_remote cwd options !targets
   | None ->
     if !shell_flag then
       Omake_shell.shell options !command_string (List.rev !targets)
@@ -213,4 +360,3 @@ let _ =
       main options
     else
       Omake_exn_print.catch main options (* Main entry point *)
-


### PR DESCRIPTION
# Split Help Screen

This P/R distributes the output of `--help` onto more help-options.
The reason is the large number of debugging flags that are rarely
needed.  We introduce two new options `--help-debug` and `--help-all`.
The latter plays the role `--help` had before.  The new output of
`--help` is everything *but* the debug options.

We raise to the occasion and enrich the output of the help screens
with the names of the option arguments, e.g. `-j N` or
`-server SERVER-NAME`.  The format now follows that of **tar(1)** or
**cpio(1)** which also suffer from the *way-too-many-flags* desease.

In the course of the change the output of `--version` was adapted,
too.

There will be a P/R that adds a manual page to the project which is
intended to augment the output of the various help-screens.

Here are the previews.

## `omake --help` (just the first lines)

```
Usage: ./src/main/omake.opt [OPTIONS...] [TARGET...]
Run OMake in the current directory to build TARGET.
If called as osh start the OMake shell Osh.

A `<N>' symbol indicates options that can be negated by
prefixing them with `--no' as, e.g., `--no-S' or
`--no--print-status'.  Note the conserved inner double
dash of the latter, though.

Options:
 Build Control:
  -j N                         specify maximum number N of parallel jobs and
                               remote servers
  -k                           do not stop when an error occurs; implied by -p
                               and -P <N>
  -p                           poll filesystem for changes (until build
                               succeeds); implies -k <N>
  -P                           poll filesystem for changes (keep polling
                               "forever"); implies -k and -p <N>
  -n                           print commands, but do not execute them <N>
```

## `omake --version`

```
OMake 0.10.3 (development snapshot):
    build [Fri Nov 19 10:50:07 2021]
    on falcon
Default library directory: /home/solo/lib/omake

License GPLv2: GNU GPL version 2 <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```
