### PR TITLE
Fix ocamldep-postproc in case-insensitive, case-preserving filesystems.

### DIFF
--- a/src/builtin/omake_builtin_ocamldep.ml
+++ b/src/builtin/omake_builtin_ocamldep.ml
@@ -37,11 +37,7 @@ let ocamldep_postproc venv pos loc args =
     try
       let name1 = String.uncapitalize_ascii name
       and name2 = String.capitalize_ascii name in
-      let names = (* check name with orignal case first *)
-        if name1 = name then
-          [name1; name2]
-        else
-          [name2; name1] in
+      let names = (* check name with uncapitalized case first *) [name1; name2] in
       match Omake_target.target_is_buildable_in_path_1 cache venv pos path names with
         | Some node ->
             Some (Omake_env.venv_nodename venv node)


### PR DESCRIPTION
On case-insensitive, case-preserving filesystems, `omake` finds invalid dependencies corresponding to paths that do not exist on disk since they have the wrong capitalization.

In particular, given module `A` that depends on `B`, and the corresponding source files `a.ml` and `b.ml`, if you have a target like `OCamlPackage(runtime, a b)`, `omake` will invoke `ocamlc` as in `ocamlc -pack -o runtime.cmo B.cmo a.cmo`. Now, on a case-insensitive, case-preserving filesystem, `b.cmo` can be open(2)ed under both `b.cmo` and `B.cmo` paths, but `ocamlc` fails -- it must be doing `readdir` and sees `B.cmo` is missing.

This is caused by a bug in the `ocamldep-postproc` builtin. I verified this by overriding its definition in an affected codebase (`extprot`) under macOS to use `OCamlScannerPostproc`, which did work.

This PR fixes the builtin itself.

## Credits

The work on this PR was performed on behalf of [Ahrefs](https://ahrefs.com/) open-source work day:
https://twitter.com/javierwchavarri/status/1466774912148910088