### PR TITLE
Fixes bootstrap build on Windows

### DIFF
--- a/src/clib/fam_win32.c
+++ b/src/clib/fam_win32.c
@@ -44,7 +44,20 @@
 #include <windows.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <caml/compatibility.h>
+
+#define HAS_STDINT_H 1
+#if defined(HAVE_STRUCT_STAT_ST_ATIM_TV_NSEC)
+#  define HAS_NANOSECOND_STAT 1
+#elif defined(HAVE_STRUCT_STAT_ST_ATIMESPEC_TV_NSEC)
+#  define HAS_NANOSECOND_STAT 2
+#elif defined(HAVE_STRUCT_STAT_ST_ATIMENSEC)
+#  define HAS_NANOSECOND_STAT 3
+#endif
+
+#ifndef _WIN32
+/* unistd.h is assumed to be available */
+#define HAS_UNISTD 1
+#endif
 
 #include "lm_compat_win32.h"
 #include "fam_pseudo.h"

--- a/src/clib/lm_notify.c
+++ b/src/clib/lm_notify.c
@@ -96,9 +96,9 @@ static int fam_connection_compare(value v1, value v2)
 #endif /* !FAM_PSEUDO */
 }
 
-static long fam_connection_hash(value v)
+static intptr_t fam_connection_hash(value v)
 {
-    return (long) FAMConnection_val(v);
+    return (intptr_t) FAMConnection_val(v);
 }
 
 static void fam_connection_finalize(value v_info)

--- a/src/clib/lm_unix_cutil.c
+++ b/src/clib/lm_unix_cutil.c
@@ -83,7 +83,7 @@ value home_win32(value v_unit)
     if(SUCCEEDED(CompatSHGetFolderPath(NULL, CSIDL_LOCAL_APPDATA | CSIDL_FLAG_CREATE, NULL, 0, path)))
         CAMLreturn(caml_copy_string(path));
 
-    failwith("home_win32");
+    caml_failwith("home_win32");
     return Val_unit;
 }
 
@@ -132,7 +132,7 @@ value lockf_win32(value v_fd, value v_kind, value v_len)
             flags = LOCKFILE_FAIL_IMMEDIATELY;
             break;
         default:
-            invalid_argument("lockf_win32");
+            caml_invalid_argument("lockf_win32");
             break;
         }
 
@@ -159,14 +159,14 @@ value lockf_win32(value v_fd, value v_kind, value v_len)
                  * XXX: HACK: this exception is being caught
                  *            Do not change the string w/o changing the wrapper code.
                  */
-                failwith("lockf_win32: already locked");
+                caml_failwith("lockf_win32: already locked");
                 break;
             case ERROR_POSSIBLE_DEADLOCK:
                 /*
                  * XXX: HACK: this exception is being caught
                  *            Do not change the string w/o changing the wrapper code.
                  */
-                failwith("lockf_win32: possible deadlock");
+                caml_failwith("lockf_win32: possible deadlock");
                 break;
             default:
                 FormatMessage(
@@ -181,7 +181,7 @@ value lockf_win32(value v_fd, value v_kind, value v_len)
                 sprintf(szBuf, "lockf_win32 failed with error %u: %s", error, (char *) lpMsgBuf); 
                 LocalFree(lpMsgBuf);
 
-                failwith(szBuf);
+                caml_failwith(szBuf);
                 break;
             }
         }


### PR DESCRIPTION
Fixes build on Windows by correcting some incompatibilities with newer versions of ocaml, mainly during the bootstrap phase.
It also fixes fam_connection_hash failing to be assigned into custom_operations on LLVM 21 stricter ruling.